### PR TITLE
SSL Certificate renew without node private key change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 | Symbol Bootstrap | v1.1.2  | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap) |
 
 - Joeynet Testnet Release.
+- Added Node SSL Certificate check and upgrade. Added `renewCertificates` command to renew the certificates.
 - The `bootstrap` preset is not the default anymore. The name must be provided via `--preset` or as a custom preset field.
 - A 'safe' custom preset is cached in the target folder. It's not required when upgrading the node without a configuration change.
 - Added `--logger` option to the commands.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ npm run style:fix
 * [`symbol-bootstrap link`](docs/link.md) - It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.
 * [`symbol-bootstrap modifyMultisig`](docs/modifyMultisig.md) - Create or modify a multisig account
 * [`symbol-bootstrap pack`](docs/pack.md) - It configures and packages your node into a zip file that can be uploaded to the final node machine.
+* [`symbol-bootstrap renewCertificates`](docs/renewCertificates.md) - It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
 * [`symbol-bootstrap report`](docs/report.md) - it generates reStructuredText (.rst) reports describing the configuration of each node.
 * [`symbol-bootstrap resetData`](docs/resetData.md) - It removes the data keeping the generated configuration, certificates, keys and block 1.
 * [`symbol-bootstrap run`](docs/run.md) - It boots the network via docker using the generated `docker-compose.yml` file and configuration. The config and compose methods/commands need to be called before this method. This is just a wrapper for the `docker-compose up` bash call.

--- a/docs/renewCertificates.md
+++ b/docs/renewCertificates.md
@@ -1,0 +1,54 @@
+`symbol-bootstrap renewCertificates`
+====================================
+
+It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
+
+This command does not change the node private key (yet). This change would require a harvesters.dat migration and relinking the node key.
+
+It's recommended to backup the target folder before running this operation!
+
+* [`symbol-bootstrap renewCertificates`](#symbol-bootstrap-renewcertificates)
+
+## `symbol-bootstrap renewCertificates`
+
+It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
+
+```
+USAGE
+  $ symbol-bootstrap renewCertificates
+
+OPTIONS
+  -c, --customPreset=customPreset  This command uses the encrypted addresses.yml to resolve the main and transport
+                                   private key. If the main and transport privates are only stored in the custom preset,
+                                   you can provide them using this param. Otherwise, the command may ask for them when
+                                   required.
+
+  -h, --help                       It shows the help of this command.
+
+  -t, --target=target              [default: target] The target folder where the symbol-bootstrap network is generated
+
+  -u, --user=user                  [default: current] User used to run docker images when generating the certificates.
+                                   "current" means the current user.
+
+  --logger=logger                  [default: Console,File] The loggers the command will use. Options are:
+                                   Console,File,Silent. Use ',' to select multiple loggers.
+
+  --noPassword                     When provided, Bootstrap will not use a password, so private keys will be stored in
+                                   plain text. Use with caution.
+
+  --password=password              A password used to encrypt and decrypt private keys in preset files like
+                                   addresses.yml and preset.yml. Bootstrap prompts for a password by default, can be
+                                   provided in the command line (--password=XXXX) or disabled in the command line
+                                   (--noPassword).
+
+DESCRIPTION
+  This command does not change the node private key (yet). This change would require a harvesters.dat migration and 
+  relinking the node key.
+
+  It's recommended to backup the target folder before running this operation!
+
+EXAMPLE
+  $ symbol-bootstrap renewCertificates
+```
+
+_See code: [src/commands/renewCertificates.ts](https://github.com/fboucquez/symbol-bootstrap/blob/v1.1.2/src/commands/renewCertificates.ts)_

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -86,7 +86,9 @@ catapultAppFolder: /usr/catapult
 enableRevoteOnBoot: true
 totalVotingBalanceCalculationFix: 0
 treasuryReissuance: 0
-
+caCertificateExpirationInDays: 7300 # 20 years
+nodeCertificateExpirationInDays: 375 # 1.02 years
+certificateExpirationWarningInDays: 30 # certificates are allowed to be renewed 30 before expiring
 # config database
 databaseName: catapult
 maxWriterThreads: 8

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -22,7 +22,7 @@ importanceGrouping: 180
 votingSetGrouping: 720
 votingKeyDesiredLifetime: 720
 votingKeyDesiredFutureLifetime: 120
-lastKnownNetworkEpoch: 125
+lastKnownNetworkEpoch: 126
 minVotingKeyLifetime: 28
 maxVotingKeyLifetime: 720
 stepDuration: 4m

--- a/src/commands/renewCertificates.ts
+++ b/src/commands/renewCertificates.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Symbol
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Command, flags } from '@oclif/command';
+import { Account } from 'symbol-sdk';
+import { LoggerFactory, System } from '../logger';
+import { CertificatePair, ConfigAccount, ConfigPreset } from '../model';
+import { BootstrapUtils, CertificateService, CommandUtils, ConfigLoader } from '../service';
+
+export default class RenewCertificates extends Command {
+    static description = `It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
+
+This command does not change the node private key (yet). This change would require a harvesters.dat migration and relinking the node key.
+
+It's recommended to backup the target folder before running this operation!
+`;
+
+    static examples = [`$ symbol-bootstrap renewCertificates`];
+
+    static flags = {
+        help: CommandUtils.helpFlag,
+        target: CommandUtils.targetFlag,
+        password: CommandUtils.passwordFlag,
+        noPassword: CommandUtils.noPasswordFlag,
+        customPreset: flags.string({
+            char: 'c',
+            description: `This command uses the encrypted addresses.yml to resolve the main and transport private key. If the main and transport privates are only stored in the custom preset, you can provide them using this param. Otherwise, the command may ask for them when required.`,
+            required: false,
+        }),
+        user: flags.string({
+            char: 'u',
+            description: `User used to run docker images when generating the certificates. "${BootstrapUtils.CURRENT_USER}" means the current user.`,
+            default: BootstrapUtils.CURRENT_USER,
+        }),
+        logger: CommandUtils.getLoggerFlag(...System),
+    };
+
+    public async run(): Promise<void> {
+        const { flags } = this.parse(RenewCertificates);
+        CommandUtils.showBanner();
+        const logger = LoggerFactory.getLogger(flags.logger);
+        const password = await CommandUtils.resolvePassword(
+            logger,
+            flags.password,
+            flags.noPassword,
+            CommandUtils.passwordPromptDefaultMessage,
+            true,
+        );
+        const target = flags.target;
+        const configLoader = new ConfigLoader(logger);
+        const presetData = configLoader.loadExistingPresetData(target, password);
+        const addresses = configLoader.loadExistingAddresses(target, password);
+        const customPreset = configLoader.loadCustomPreset(flags.customPreset, password);
+        const mergedPresetData: ConfigPreset = configLoader.mergePresets(presetData, customPreset);
+
+        const networkType = presetData.networkType;
+        const certificateService = new CertificateService(logger, {
+            target,
+            user: flags.user,
+        });
+        const certificateUpgraded = (
+            await Promise.all(
+                (mergedPresetData.nodes || []).map((nodePreset, index) => {
+                    const nodeAccount = addresses.nodes?.[index];
+                    if (!nodeAccount) {
+                        throw new Error(`There is not node in addresses at index ${index}`);
+                    }
+                    function resolveAccount(configAccount: ConfigAccount, providedPrivateKey: string | undefined): CertificatePair {
+                        if (providedPrivateKey) {
+                            const account = Account.createFromPrivateKey(providedPrivateKey, networkType);
+                            if (account.address.plain() == configAccount.address) {
+                                return account;
+                            }
+                        }
+                        return configAccount;
+                    }
+                    const providedCertificates = {
+                        main: resolveAccount(nodeAccount.main, nodePreset.mainPrivateKey),
+                        transport: resolveAccount(nodeAccount.transport, nodePreset.transportPrivateKey),
+                    };
+                    return certificateService.run(mergedPresetData, nodePreset.name, providedCertificates, true);
+                }),
+            )
+        ).find((f) => f);
+        if (certificateUpgraded) {
+            logger.warn('');
+            logger.warn('Bootstrap has created new SSL certificates. Review the logs!');
+            logger.warn('');
+        } else {
+            logger.info('');
+            logger.info('The SSL certificates are up-to-date. There is nothing to upgrade.');
+            logger.info('');
+        }
+    }
+}

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -251,6 +251,9 @@ export interface NodeConfigPreset {
     maxProofSize: number;
     maxTransactionsPerBlock: number;
     localNetworks: string;
+    caCertificateExpirationInDays: number;
+    nodeCertificateExpirationInDays: number;
+    certificateExpirationWarningInDays: number;
 }
 
 export interface NodePreset extends DockerServicePreset, Partial<NodeConfigPreset> {

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -319,15 +319,11 @@ export class ConfigService {
     private async generateNodeCertificates(presetData: ConfigPreset, addresses: Addresses): Promise<void> {
         await Promise.all(
             (addresses.nodes || []).map((account) => {
-                return new CertificateService(this.logger, this.params).run(
-                    presetData.networkType,
-                    presetData.symbolServerImage,
-                    account.name,
-                    {
-                        main: account.main,
-                        transport: account.transport,
-                    },
-                );
+                const providedCertificates = {
+                    main: account.main,
+                    transport: account.transport,
+                };
+                return new CertificateService(this.logger, this.params).run(presetData, account.name, providedCertificates, false);
             }),
         );
     }

--- a/src/service/RunService.ts
+++ b/src/service/RunService.ts
@@ -22,6 +22,7 @@ import { RepositoryFactoryHttp } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { DockerCompose, DockerComposeService } from '../model';
 import { BootstrapUtils } from './BootstrapUtils';
+import { CertificateService } from './CertificateService';
 import { ConfigLoader } from './ConfigLoader';
 import { OSUtils } from './OSUtils';
 import { PortService } from './PortService';
@@ -89,9 +90,11 @@ export class RunService {
             this.logger.info(`Docker compose ${dockerFile} does not exist. Cannot check the status of the service.`);
             return;
         }
+        if (!(await this.checkCertificates())) {
+            throw new Error(`Certificates are about to expire. Check the logs!`);
+        }
         const dockerCompose: DockerCompose = BootstrapUtils.fromYaml(await BootstrapUtils.readTextFile(dockerFile));
         const services = Object.values(dockerCompose.services);
-
         const timeout = this.params.timeout || RunService.defaultParams.timeout || 0;
         const started = await BootstrapUtils.poll(this.logger, () => this.runOneCheck(services), timeout, pollIntervalMs);
         if (!started) {
@@ -99,6 +102,32 @@ export class RunService {
         } else {
             this.logger.info('Network is running!');
         }
+    }
+
+    private async checkCertificates(): Promise<boolean> {
+        const presetData = this.configLoader.loadExistingPresetData(this.params.target, false);
+        const service = new CertificateService(this.logger, { target: this.params.target, user: BootstrapUtils.CURRENT_USER });
+        const allServicesChecks: Promise<boolean>[] = (presetData.nodes || []).map(async (nodePreset) => {
+            const name = nodePreset.name;
+            const certFolder = BootstrapUtils.getTargetNodesFolder(this.params.target, false, name, 'cert');
+            const willExpireReport = await service.willCertificateExpire(
+                presetData.symbolServerImage,
+                certFolder,
+                CertificateService.NODE_CERTIFICATE_FILE_NAME,
+                presetData.certificateExpirationWarningInDays,
+            );
+            if (willExpireReport.willExpire) {
+                this.logger.warn(
+                    `The ${CertificateService.NODE_CERTIFICATE_FILE_NAME} certificate for node ${name} will expire in less than ${presetData.certificateExpirationWarningInDays} days on ${willExpireReport.expirationDate}. You need to renew it.`,
+                );
+            } else {
+                this.logger.info(
+                    `The ${CertificateService.NODE_CERTIFICATE_FILE_NAME} certificate for node ${name} will expire on ${willExpireReport.expirationDate}. No need to renew it yet.`,
+                );
+            }
+            return !willExpireReport.willExpire;
+        });
+        return (await Promise.all(allServicesChecks)).every((t) => t);
     }
 
     private async runOneCheck(services: DockerComposeService[]): Promise<boolean> {

--- a/test/service/RuntimeService.test.ts
+++ b/test/service/RuntimeService.test.ts
@@ -25,6 +25,12 @@ describe('RuntimeService', async () => {
         }
     });
 
+    it('exec when invalid ignore error', async () => {
+        const result = await service.exec('wrong!', true);
+        expect(result.stderr.indexOf('wrong!')).not.eq(-1);
+        expect(result.stdout).eq('');
+    });
+
     it('spawn when valid', async () => {
         const response = await service.spawn({ command: 'echo', args: ['ABC'], useLogger: true, logPrefix: '', shell: true });
         expect(response).eq('ABC\n');


### PR DESCRIPTION
feat: renewCertificates command - Only updates when the certificate expires in less than 30 days.
feat: certificate expiration warnings when upgrading - When the certificate expires in less than 30 days
feat: certificate expiration check in healthCheck  - Fails when the certificate expires in less than 30 days.

This is the initial work for the https://github.com/symbol/symbol-bootstrap/issues/285

Currently, this PR will help node admins renewing a node SSL certificate but without changing the node/transport private key (or main private key). Ideally, the SSL node certificate is renewed, a new node/transport private key should be used. This requires harvesters.dat migration and a node key relink (link command handles that already).

Once we have the harverters.dat migration tool (catapult tool or ts native if possible), I would include the migration to the `renewCertificates` so the migration is fairly simple while keeping the security standards by default.

