### PR TITLE
fix: Account Resolver

### DIFF
--- a/presets/mainnet/network.yml
+++ b/presets/mainnet/network.yml
@@ -27,7 +27,7 @@ minVotingKeyLifetime: 112
 maxVotingKeyLifetime: 360
 votingKeyDesiredLifetime: 360
 votingKeyDesiredFutureLifetime: 60
-lastKnownNetworkEpoch: 613
+lastKnownNetworkEpoch: 615
 stepDuration: 5m
 maxBlockFutureTime: 300ms
 maxAccountRestrictionValues: 100

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -22,7 +22,7 @@ importanceGrouping: 180
 votingSetGrouping: 720
 votingKeyDesiredLifetime: 720
 votingKeyDesiredFutureLifetime: 120
-lastKnownNetworkEpoch: 139
+lastKnownNetworkEpoch: 142
 minVotingKeyLifetime: 28
 maxVotingKeyLifetime: 720
 stepDuration: 4m

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -17,6 +17,7 @@
 import { Command, flags } from '@oclif/command';
 import { LoggerFactory, System } from '../logger';
 import { Assembly, BootstrapService, CommandUtils, ConfigService, Constants, Preset } from '../service';
+import { Assembly, BootstrapAccountResolver, BootstrapService, BootstrapUtils, CommandUtils, ConfigService, Preset } from '../service';
 
 export default class Config extends Command {
     static description = 'Command used to set up the configuration files and the nemesis block for the current network';
@@ -86,6 +87,8 @@ export default class Config extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        await new BootstrapService(logger).config({ ...flags, workingDir: Constants.defaultWorkingDir });
+        const workingDir = Constants.defaultWorkingDir;
+        const accountResolver = new BootstrapAccountResolver(logger);
+        await new BootstrapService(logger).config({ ...flags, workingDir, accountResolver, workingDir });
     }
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -16,8 +16,7 @@
 
 import { Command, flags } from '@oclif/command';
 import { LoggerFactory, System } from '../logger';
-import { Assembly, BootstrapService, CommandUtils, ConfigService, Constants, Preset } from '../service';
-import { Assembly, BootstrapAccountResolver, BootstrapService, BootstrapUtils, CommandUtils, ConfigService, Preset } from '../service';
+import { Assembly, BootstrapAccountResolver, BootstrapService, CommandUtils, ConfigService, Constants, Preset } from '../service';
 
 export default class Config extends Command {
     static description = 'Command used to set up the configuration files and the nemesis block for the current network';
@@ -89,6 +88,6 @@ export default class Config extends Command {
         );
         const workingDir = Constants.defaultWorkingDir;
         const accountResolver = new BootstrapAccountResolver(logger);
-        await new BootstrapService(logger).config({ ...flags, workingDir, accountResolver, workingDir });
+        await new BootstrapService(logger).config({ ...flags, workingDir, accountResolver });
     }
 }

--- a/src/commands/decrypt.ts
+++ b/src/commands/decrypt.ts
@@ -17,9 +17,8 @@
 import { Command, flags } from '@oclif/command';
 import { existsSync } from 'fs';
 import { dirname } from 'path';
-import { BootstrapUtils, CommandUtils, FileSystemService, KnownError, LoggerFactory, LogType } from '../';
 import { LoggerFactory, LogType } from '../logger';
-import { BootstrapUtils, CommandUtils, KnownError } from '../service';
+import { BootstrapUtils, CommandUtils, FileSystemService, KnownError } from '../service';
 
 export default class Decrypt extends Command {
     static description = `It decrypts a yml file using the provided password. The source file can be a custom preset file, a preset.yml file or an addresses.yml.

--- a/src/commands/decrypt.ts
+++ b/src/commands/decrypt.ts
@@ -18,6 +18,8 @@ import { Command, flags } from '@oclif/command';
 import { existsSync } from 'fs';
 import { dirname } from 'path';
 import { BootstrapUtils, CommandUtils, FileSystemService, KnownError, LoggerFactory, LogType } from '../';
+import { LoggerFactory, LogType } from '../logger';
+import { BootstrapUtils, CommandUtils, KnownError } from '../service';
 
 export default class Decrypt extends Command {
     static description = `It decrypts a yml file using the provided password. The source file can be a custom preset file, a preset.yml file or an addresses.yml.

--- a/src/commands/encrypt.ts
+++ b/src/commands/encrypt.ts
@@ -17,9 +17,8 @@
 import { Command, flags } from '@oclif/command';
 import { existsSync } from 'fs';
 import { dirname } from 'path';
-import { BootstrapUtils, CommandUtils, CryptoUtils, FileSystemService, KnownError, LoggerFactory, LogType } from '../';
 import { LoggerFactory, LogType } from '../logger';
-import { BootstrapUtils, CommandUtils, CryptoUtils, KnownError } from '../service';
+import { BootstrapUtils, CommandUtils, CryptoUtils, FileSystemService, KnownError } from '../service';
 
 export default class Encrypt extends Command {
     static description = `It encrypts a yml file using the provided password. The source files would be a custom preset file, a preset.yml file or an addresses.yml.

--- a/src/commands/encrypt.ts
+++ b/src/commands/encrypt.ts
@@ -18,6 +18,8 @@ import { Command, flags } from '@oclif/command';
 import { existsSync } from 'fs';
 import { dirname } from 'path';
 import { BootstrapUtils, CommandUtils, CryptoUtils, FileSystemService, KnownError, LoggerFactory, LogType } from '../';
+import { LoggerFactory, LogType } from '../logger';
+import { BootstrapUtils, CommandUtils, CryptoUtils, KnownError } from '../service';
 
 export default class Encrypt extends Command {
     static description = `It encrypts a yml file using the provided password. The source files would be a custom preset file, a preset.yml file or an addresses.yml.

--- a/src/commands/healthCheck.ts
+++ b/src/commands/healthCheck.ts
@@ -15,7 +15,8 @@
  */
 
 import { Command } from '@oclif/command';
-import { BootstrapService, CommandUtils, LoggerFactory, System } from '../';
+import { LoggerFactory, System } from '../logger';
+import { BootstrapService, CommandUtils } from '../service';
 
 export default class HealthCheck extends Command {
     static description = `It checks if the services created with docker compose are up and running.

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -15,8 +15,8 @@
  */
 
 import { Command, flags } from '@oclif/command';
-import { AnnounceService, BootstrapService, CommandUtils, LoggerFactory, LogType } from '../';
-import { LinkService } from '../service';
+import { LoggerFactory, LogType } from '../logger';
+import { AnnounceService, BootstrapService, CommandUtils, LinkService } from '../service';
 
 export default class Link extends Command {
     static description = `It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.`;

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -18,20 +18,18 @@ import { Command, flags } from '@oclif/command';
 import { existsSync } from 'fs';
 import { prompt } from 'inquirer';
 import { dirname, join } from 'path';
+import { LoggerFactory, LogType } from '../logger';
 import {
+    BootstrapAccountResolver,
     BootstrapService,
     BootstrapUtils,
     CommandUtils,
     Constants,
     CryptoUtils,
     FileSystemService,
-    LoggerFactory,
-    LogType,
     ZipItem,
     ZipUtils,
-} from '../';
-import { LoggerFactory, LogType } from '../logger';
-import { BootstrapAccountResolver, BootstrapService, BootstrapUtils, CommandUtils, CryptoUtils, ZipItem, ZipUtils } from '../service';
+} from '../service';
 import Clean from './clean';
 import Compose from './compose';
 import Config from './config';
@@ -98,7 +96,7 @@ export default class Pack extends Command {
         const service = new BootstrapService(logger);
         const configOnlyCustomPresetFileName = 'config-only-custom-preset.yml';
         const accountResolver = new BootstrapAccountResolver(logger);
-        const configResult = await service.config({ ...flags, workingDir});
+        const configResult = await service.config({ ...flags, workingDir, accountResolver });
         await service.compose(flags, configResult.presetData);
 
         const noPrivateKeyTempFile = 'custom-preset-temp.temp';

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -30,6 +30,8 @@ import {
     ZipItem,
     ZipUtils,
 } from '../';
+import { LoggerFactory, LogType } from '../logger';
+import { BootstrapAccountResolver, BootstrapService, BootstrapUtils, CommandUtils, CryptoUtils, ZipItem, ZipUtils } from '../service';
 import Clean from './clean';
 import Compose from './compose';
 import Config from './config';
@@ -92,9 +94,11 @@ export default class Pack extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
+        const workingDir = Constants.defaultWorkingDir;
         const service = new BootstrapService(logger);
         const configOnlyCustomPresetFileName = 'config-only-custom-preset.yml';
-        const configResult = await service.config({ ...flags, workingDir: Constants.defaultWorkingDir });
+        const accountResolver = new BootstrapAccountResolver(logger);
+        const configResult = await service.config({ ...flags, workingDir});
         await service.compose(flags, configResult.presetData);
 
         const noPrivateKeyTempFile = 'custom-preset-temp.temp';

--- a/src/commands/renewCertificates.ts
+++ b/src/commands/renewCertificates.ts
@@ -17,7 +17,7 @@ import { Command, flags } from '@oclif/command';
 import { Account } from 'symbol-sdk';
 import { LoggerFactory, System } from '../logger';
 import { CertificatePair, ConfigAccount, ConfigPreset } from '../model';
-import { CertificateService, CommandUtils, ConfigLoader, Constants } from '../service';
+import { BootstrapAccountResolver, CertificateService, CommandUtils, ConfigLoader, Constants } from '../service';
 
 export default class RenewCertificates extends Command {
     static description = `It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
@@ -66,7 +66,8 @@ It's recommended to backup the target folder before running this operation!
         const mergedPresetData: ConfigPreset = configLoader.mergePresets(presetData, customPreset);
 
         const networkType = presetData.networkType;
-        const certificateService = new CertificateService(logger, {
+        const accountResolver = new BootstrapAccountResolver(logger);
+        const certificateService = new CertificateService(logger, accountResolver, {
             target,
             user: flags.user,
         });

--- a/src/commands/resetData.ts
+++ b/src/commands/resetData.ts
@@ -15,7 +15,8 @@
  */
 
 import { Command } from '@oclif/command';
-import { BootstrapService, CommandUtils, LoggerFactory, System } from '../';
+import { LoggerFactory, System } from '../logger';
+import { BootstrapService, CommandUtils } from '../service';
 
 export default class ResetData extends Command {
     static description = 'It removes the data keeping the generated configuration, certificates, keys and block 1.';

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -16,8 +16,7 @@
 
 import { Command } from '@oclif/command';
 import { LoggerFactory } from '../logger';
-import { BootstrapAccountResolver, BootstrapService, BootstrapUtils, CommandUtils } from '../service';
-import { BootstrapService, CommandUtils, Constants } from '../service';
+import { BootstrapAccountResolver, BootstrapService, CommandUtils, Constants } from '../service';
 import Clean from './clean';
 import Compose from './compose';
 import Config from './config';
@@ -50,8 +49,7 @@ export default class Start extends Command {
             true,
         );
 
-      const workingDir = Constants.defaultWorkingDir;
-      await new BootstrapService(logger).start({ ...flags, workingDir });
+        const workingDir = Constants.defaultWorkingDir;
         const accountResolver = new BootstrapAccountResolver(logger);
         await new BootstrapService(logger).start({ ...flags, accountResolver, workingDir });
     }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -16,6 +16,7 @@
 
 import { Command } from '@oclif/command';
 import { LoggerFactory } from '../logger';
+import { BootstrapAccountResolver, BootstrapService, BootstrapUtils, CommandUtils } from '../service';
 import { BootstrapService, CommandUtils, Constants } from '../service';
 import Clean from './clean';
 import Compose from './compose';
@@ -48,6 +49,10 @@ export default class Start extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        await new BootstrapService(logger).start({ ...flags, workingDir: Constants.defaultWorkingDir });
+
+      const workingDir = Constants.defaultWorkingDir;
+      await new BootstrapService(logger).start({ ...flags, workingDir });
+        const accountResolver = new BootstrapAccountResolver(logger);
+        await new BootstrapService(logger).start({ ...flags, accountResolver, workingDir });
     }
 }

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -15,7 +15,8 @@
  */
 
 import { Command } from '@oclif/command';
-import { CommandUtils, LoggerFactory, System, VerifyService } from '../';
+import { LoggerFactory, System } from '../logger';
+import { CommandUtils, VerifyService } from '../service';
 
 export default class Verify extends Command {
     static description =

--- a/src/model/Addresses.ts
+++ b/src/model/Addresses.ts
@@ -53,7 +53,7 @@ export interface Addresses {
     version: number;
     nodes?: NodeAccount[];
     nemesisGenerationHashSeed: string;
-    sinkAddress: string;
+    sinkAddress?: string;
     nemesisSigner?: ConfigAccount;
     networkType: NetworkType;
     mosaics?: MosaicAccounts[];

--- a/src/service/AccountResolver.ts
+++ b/src/service/AccountResolver.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Account, NetworkType } from 'symbol-sdk';
+import { CertificatePair, KeyName } from '../';
+
+/**
+ * Delegate that knows how to retrieve or generate accounts.
+ *
+ * Implementations of this interface could for example prompt or load accounts from a key store.
+ */
+export interface AccountResolver {
+    resolveAccount(
+        networkType: NetworkType,
+        account: CertificatePair | undefined,
+        keyName: KeyName,
+        nodeName: string | undefined,
+        operationDescription: string,
+        generateErrorMessage: string | undefined,
+    ): Promise<Account>;
+}
+
+/**
+ * Basic no prompt implementation. If the account cannot be resolved, it won't be prompted.
+ */
+export class DefaultAccountResolver implements AccountResolver {
+    async resolveAccount(
+        networkType: NetworkType,
+        account: CertificatePair | undefined,
+        keyName: KeyName,
+        nodeName: string,
+        operationDescription: string,
+        generateErrorMessage: string | undefined,
+    ): Promise<Account> {
+        if (!account) {
+            if (generateErrorMessage) {
+                throw new Error(generateErrorMessage);
+            }
+            return this.generateNewAccount(networkType);
+        }
+        if (account?.privateKey) {
+            return Account.createFromPrivateKey(account.privateKey, networkType);
+        }
+        throw new Error('Private key not provided');
+    }
+
+    generateNewAccount(networkType: NetworkType): Account {
+        return Account.generateNewAccount(networkType);
+    }
+}

--- a/src/service/AddressesService.ts
+++ b/src/service/AddressesService.ts
@@ -1,0 +1,371 @@
+import { Account, Address, Convert, Crypto, MosaicId, MosaicNonce, NetworkType, PublicAccount } from 'symbol-sdk';
+import { Logger } from '../logger';
+import { Addresses, ConfigAccount, ConfigPreset, MosaicAccounts, NodeAccount, NodePreset, PrivateKeySecurityMode } from '../model';
+import { AccountResolver } from './AccountResolver';
+import { BootstrapUtils } from './BootstrapUtils';
+import { KeyName } from './ConfigService';
+import { ConfigurationUtils } from './ConfigurationUtils';
+import { CryptoUtils } from './CryptoUtils';
+import { MigrationService } from './MigrationService';
+
+/**
+ * Object in charge of resolving the address.yml and its accounts.
+ */
+export class AddressesService {
+    private readonly migrationService: MigrationService;
+    constructor(private readonly logger: Logger, private readonly accountResolver: AccountResolver) {
+        this.migrationService = new MigrationService(this.logger);
+    }
+
+    public async resolveAddresses(
+        oldAddresses: Addresses | undefined,
+        oldPresetData: ConfigPreset | undefined,
+        presetData: ConfigPreset,
+    ): Promise<Addresses> {
+        const networkType = presetData.networkType;
+        const addresses: Addresses = {
+            version: this.migrationService.getAddressesMigration(presetData.networkType).length + 1,
+            networkType: networkType,
+            nemesisGenerationHashSeed:
+                presetData.nemesisGenerationHashSeed ||
+                oldAddresses?.nemesisGenerationHashSeed ||
+                Convert.uint8ToHex(Crypto.randomBytes(32)),
+            sinkAddress: presetData.sinkAddress || oldAddresses?.sinkAddress,
+        };
+
+        //Sync address is generated on demand only
+        const resolveSyncAddress = (providedAddress: string | undefined): string => {
+            if (providedAddress) {
+                return Address.createFromRawAddress(providedAddress).plain();
+            }
+            addresses.sinkAddress = addresses.sinkAddress || Account.generateNewAccount(networkType).address.plain();
+            return addresses.sinkAddress;
+        };
+
+        presetData.harvestNetworkFeeSinkAddress = resolveSyncAddress(presetData.harvestNetworkFeeSinkAddress);
+        presetData.mosaicRentalFeeSinkAddress = resolveSyncAddress(presetData.mosaicRentalFeeSinkAddress);
+        presetData.namespaceRentalFeeSinkAddress = resolveSyncAddress(presetData.namespaceRentalFeeSinkAddress);
+
+        if (!presetData.harvestNetworkFeeSinkAddressV1) {
+            presetData.harvestNetworkFeeSinkAddressV1 = presetData.harvestNetworkFeeSinkAddress;
+        }
+        if (!presetData.mosaicRentalFeeSinkAddressV1) {
+            presetData.mosaicRentalFeeSinkAddressV1 = presetData.mosaicRentalFeeSinkAddress;
+        }
+        if (!presetData.namespaceRentalFeeSinkAddressV1) {
+            presetData.namespaceRentalFeeSinkAddressV1 = presetData.namespaceRentalFeeSinkAddress;
+        }
+        presetData.networkIdentifier = BootstrapUtils.getNetworkIdentifier(networkType);
+        presetData.networkName = BootstrapUtils.getNetworkName(networkType);
+        presetData.nemesisGenerationHashSeed = addresses.nemesisGenerationHashSeed;
+        addresses.nodes = await this.resolveNodesAccounts(oldAddresses, presetData, networkType);
+
+        const shouldCreateNemesis = ConfigurationUtils.shouldCreateNemesis(presetData);
+        if (shouldCreateNemesis) {
+            const nemesisSigner = this.resolveNemesisAccount(presetData, oldAddresses);
+            if (!nemesisSigner.privateKey) {
+                throw new Error('Nemesis Signer Private Key should be resolved!');
+            }
+            addresses.nemesisSigner = nemesisSigner;
+            presetData.nemesisSignerPublicKey = nemesisSigner.publicKey;
+            presetData.nemesis.nemesisSignerPrivateKey = nemesisSigner.privateKey;
+        }
+
+        const nemesisSignerAddress = Address.createFromPublicKey(presetData.nemesisSignerPublicKey, networkType);
+
+        if (!presetData.currencyMosaicId)
+            presetData.currencyMosaicId = MosaicId.createFromNonce(MosaicNonce.createFromNumber(0), nemesisSignerAddress).toHex();
+
+        if (!presetData.harvestingMosaicId) {
+            if (!presetData.nemesis) {
+                throw new Error('nemesis must be defined!');
+            }
+            if (presetData.nemesis.mosaics && presetData.nemesis.mosaics.length > 1) {
+                presetData.harvestingMosaicId = MosaicId.createFromNonce(MosaicNonce.createFromNumber(1), nemesisSignerAddress).toHex();
+            } else {
+                presetData.harvestingMosaicId = presetData.currencyMosaicId;
+            }
+        }
+
+        if (shouldCreateNemesis) {
+            if (oldAddresses) {
+                if (!oldPresetData) {
+                    throw new Error('oldPresetData must be defined when upgrading!');
+                }
+                // Nemesis configuration cannot be changed on upgrade.
+                addresses.mosaics = oldAddresses.mosaics;
+                presetData.nemesis = oldPresetData.nemesis;
+            } else {
+                addresses.mosaics = this.processNemesisBalances(presetData, addresses, nemesisSignerAddress);
+            }
+        }
+
+        return addresses;
+    }
+    private sum(distribution: { amount: number; address: string }[], mosaicName: string) {
+        return distribution
+            .map((d, index) => {
+                if (d.amount < 0) {
+                    throw new Error(
+                        `Nemesis distribution balance cannot be less than 0. Mosaic ${mosaicName}, distribution address: ${
+                            d.address
+                        }, amount: ${d.amount}, index ${index}. \nDistributions are:\n${BootstrapUtils.toYaml(distribution)}`,
+                    );
+                }
+                return d.amount;
+            })
+            .reduce((a, b) => a + b, 0);
+    }
+
+    private resolveNemesisAccount(presetData: ConfigPreset, oldAddresses: Addresses | undefined): ConfigAccount {
+        const networkType = presetData.networkType;
+        const signerPrivateKey =
+            presetData.nemesis.nemesisSignerPrivateKey ||
+            oldAddresses?.nemesisSigner?.privateKey ||
+            Account.generateNewAccount(networkType).privateKey;
+
+        const signerPublicKey = presetData.nemesisSignerPublicKey || oldAddresses?.nemesisSigner?.publicKey;
+        const nemesisSigner = ConfigurationUtils.toConfigAccountFomKeys(networkType, signerPublicKey, signerPrivateKey);
+
+        if (!nemesisSigner) {
+            throw new Error('Nemesis Signer should be resolved!');
+        }
+        return nemesisSigner;
+    }
+
+    private processNemesisBalances(presetData: ConfigPreset, addresses: Addresses, nemesisSignerAddress: Address): MosaicAccounts[] {
+        const privateKeySecurityMode = CryptoUtils.getPrivateKeySecurityMode(presetData.privateKeySecurityMode);
+        const networkType = presetData.networkType;
+        const mosaics: MosaicAccounts[] = [];
+        presetData.nemesis.mosaics.forEach((m, mosaicIndex) => {
+            const accounts = this.generateAddresses(networkType, privateKeySecurityMode, m.accounts);
+            const id = MosaicId.createFromNonce(MosaicNonce.createFromNumber(mosaicIndex), nemesisSignerAddress).toHex();
+            mosaics.push({
+                id: id,
+                name: m.name,
+                accounts,
+            });
+            const getBalance = (nodeIndex: number): number | undefined => {
+                const node = presetData?.nodes?.[nodeIndex];
+                if (!node) {
+                    return undefined;
+                }
+                const balance = node?.balances?.[mosaicIndex];
+                if (balance !== undefined) {
+                    return balance;
+                }
+                if (node.excludeFromNemesis) {
+                    return 0;
+                }
+                return undefined;
+            };
+            const providedDistributions = [...(m.currencyDistributions || [])];
+            addresses.nodes?.forEach((node, index) => {
+                const balance = getBalance(index);
+                if (balance !== undefined)
+                    providedDistributions.push({
+                        address: node.main.address,
+                        amount: balance,
+                    });
+            });
+            const nodeMainAccounts = (addresses.nodes || []).filter((node, index) => node.main && getBalance(index) === undefined);
+            const providedSupply = this.sum(providedDistributions, m.name);
+            const remainingSupply = m.supply - providedSupply;
+            if (remainingSupply < 0) {
+                throw new Error(
+                    `Mosaic ${m.name}'s fixed distributed supply ${providedSupply} is grater than mosaic total supply ${m.supply}`,
+                );
+            }
+            const dynamicAccounts = accounts.length + nodeMainAccounts.length;
+            const amountPerAccount = Math.floor(remainingSupply / dynamicAccounts);
+            const maxHarvesterBalance = this.getMaxHarvesterBalance(presetData, mosaicIndex);
+            const generatedAccounts = [
+                ...accounts.map((a) => ({
+                    address: a.address,
+                    amount: amountPerAccount,
+                })),
+                ...nodeMainAccounts.map((n) => ({
+                    address: n.main.address,
+                    amount: Math.min(maxHarvesterBalance, amountPerAccount),
+                })),
+            ];
+            m.currencyDistributions = [...generatedAccounts, ...providedDistributions].filter((d) => d.amount > 0);
+
+            const generatedSupply = this.sum(generatedAccounts.slice(1), m.name);
+
+            m.currencyDistributions[0].amount = m.supply - providedSupply - generatedSupply;
+
+            const supplied = this.sum(m.currencyDistributions, m.name);
+            if (m.supply != supplied) {
+                throw new Error(
+                    `Invalid nemgen total supplied value, expected ${
+                        m.supply
+                    } but total is ${supplied}. \nDistributions are:\n${BootstrapUtils.toYaml(m.currencyDistributions)}`,
+                );
+            }
+        });
+        return mosaics;
+    }
+
+    private getMaxHarvesterBalance(presetData: ConfigPreset, mosaicIndex: number) {
+        return (presetData.nemesis.mosaics.length == 1 && mosaicIndex == 0) || (presetData.nemesis.mosaics.length > 1 && mosaicIndex == 1)
+            ? presetData.maxHarvesterBalance
+            : Number.MAX_SAFE_INTEGER;
+    }
+
+    public async resolveNodesAccounts(
+        oldAddresses: Addresses | undefined,
+        presetData: ConfigPreset,
+        networkType: NetworkType,
+    ): Promise<NodeAccount[]> {
+        return Promise.all(
+            (presetData.nodes || []).map((node, index) =>
+                this.resolveNodeAccounts(oldAddresses?.nodes?.[index], presetData, index, node, networkType),
+            ),
+        );
+    }
+
+    public async resolveNodeAccounts(
+        oldNodeAccount: NodeAccount | undefined,
+        presetData: ConfigPreset,
+        index: number,
+        nodePreset: NodePreset,
+        networkType: NetworkType,
+    ): Promise<NodeAccount> {
+        const privateKeySecurityMode = CryptoUtils.getPrivateKeySecurityMode(presetData.privateKeySecurityMode);
+        const name = nodePreset.name || `node-${index}`;
+        const main = await this.resolveAccount(
+            networkType,
+            privateKeySecurityMode,
+            KeyName.Main,
+            nodePreset.name,
+            oldNodeAccount?.main,
+            ConfigurationUtils.toConfigAccountFomKeys(networkType, nodePreset.mainPublicKey, nodePreset.mainPrivateKey),
+        );
+        const transport = await this.resolveAccount(
+            networkType,
+            privateKeySecurityMode,
+            KeyName.Transport,
+            nodePreset.name,
+            oldNodeAccount?.transport,
+            ConfigurationUtils.toConfigAccountFomKeys(networkType, nodePreset.transportPublicKey, nodePreset.transportPrivateKey),
+        );
+
+        const friendlyName = nodePreset.friendlyName || main.publicKey.substr(0, 7);
+
+        const nodeAccount: NodeAccount = {
+            name,
+            friendlyName,
+            roles: ConfigurationUtils.resolveRoles(nodePreset),
+            main: main,
+            transport: transport,
+        };
+
+        const useRemoteAccount = nodePreset.nodeUseRemoteAccount || presetData.nodeUseRemoteAccount;
+
+        if (useRemoteAccount && (nodePreset.harvesting || nodePreset.voting))
+            nodeAccount.remote = await this.resolveAccount(
+                networkType,
+                privateKeySecurityMode,
+                KeyName.Remote,
+                nodePreset.name,
+                oldNodeAccount?.remote,
+                ConfigurationUtils.toConfigAccountFomKeys(networkType, nodePreset.remotePublicKey, nodePreset.remotePrivateKey),
+            );
+        if (nodePreset.harvesting)
+            nodeAccount.vrf = await this.resolveAccount(
+                networkType,
+                privateKeySecurityMode,
+                KeyName.VRF,
+                nodePreset.name,
+                oldNodeAccount?.vrf,
+                ConfigurationUtils.toConfigAccountFomKeys(networkType, nodePreset.vrfPublicKey, nodePreset.vrfPrivateKey),
+            );
+
+        return nodeAccount;
+    }
+
+    public generateAddresses(
+        networkType: NetworkType,
+        privateKeySecurityMode: PrivateKeySecurityMode,
+        accounts: number | string[],
+    ): ConfigAccount[] {
+        if (typeof accounts == 'number') {
+            return [...Array(accounts).keys()].map(() => ConfigurationUtils.toConfigAccount(Account.generateNewAccount(networkType)));
+        } else {
+            return accounts.map((key) => ConfigurationUtils.toConfigAccount(PublicAccount.createFromPublicKey(key, networkType)));
+        }
+    }
+    public resolveGenerateErrorMessage(keyName: KeyName, privateKeySecurityMode: PrivateKeySecurityMode): string | undefined {
+        if (
+            keyName === KeyName.Main &&
+            (privateKeySecurityMode === PrivateKeySecurityMode.PROMPT_ALL ||
+                privateKeySecurityMode === PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT ||
+                privateKeySecurityMode === PrivateKeySecurityMode.PROMPT_MAIN)
+        ) {
+            return `Account ${keyName} cannot be generated when Private Key Security Mode is ${privateKeySecurityMode}. Account won't be stored anywhere!. Please use ${PrivateKeySecurityMode.ENCRYPT}, or provider your ${keyName} account with custom presets!`;
+        }
+        if (
+            keyName === KeyName.Transport &&
+            (privateKeySecurityMode === PrivateKeySecurityMode.PROMPT_ALL ||
+                privateKeySecurityMode === PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT)
+        ) {
+            return `Account ${keyName} cannot be generated when Private Key Security Mode is ${privateKeySecurityMode}. Account won't be stored anywhere!. Please use ${PrivateKeySecurityMode.ENCRYPT}, ${PrivateKeySecurityMode.PROMPT_MAIN}, or provider your ${keyName} account with custom presets!`;
+        } else {
+            if (privateKeySecurityMode === PrivateKeySecurityMode.PROMPT_ALL) {
+                return `Account ${keyName} cannot be generated when Private Key Security Mode is ${privateKeySecurityMode}. Account won't be stored anywhere! Please use ${PrivateKeySecurityMode.ENCRYPT}, ${PrivateKeySecurityMode.PROMPT_MAIN}, ${PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT}, or provider your ${keyName} account with custom presets!`;
+            }
+        }
+        return undefined;
+    }
+    public async resolveAccount(
+        networkType: NetworkType,
+        privateKeySecurityMode: PrivateKeySecurityMode,
+        keyName: KeyName,
+        nodeName: string,
+        oldStoredAccount: ConfigAccount | undefined,
+        newProvidedAccount: ConfigAccount | undefined,
+    ): Promise<ConfigAccount> {
+        const oldAccount = ConfigurationUtils.toAccount(
+            networkType,
+            oldStoredAccount?.publicKey.toUpperCase(),
+            oldStoredAccount?.privateKey?.toUpperCase(),
+        );
+        const newAccount = ConfigurationUtils.toAccount(
+            networkType,
+            newProvidedAccount?.publicKey?.toUpperCase(),
+            newProvidedAccount?.privateKey?.toUpperCase(),
+        );
+
+        const getAccountLog = (a: Account | PublicAccount) => `${keyName} Account ${a.address.plain()} Public Key ${a.publicKey} `;
+
+        if (oldAccount && newAccount) {
+            if (oldAccount.address.equals(newAccount.address)) {
+                this.logger.info(`Reusing ${getAccountLog(newAccount)}`);
+                return { ...ConfigurationUtils.toConfigAccount(oldAccount), ...ConfigurationUtils.toConfigAccount(newAccount) };
+            }
+            this.logger.info(`Old ${getAccountLog(oldAccount)} has been changed. New ${getAccountLog(newAccount)} replaces it.`);
+            return ConfigurationUtils.toConfigAccount(newAccount);
+        }
+        if (oldAccount) {
+            this.logger.info(`Reusing ${getAccountLog(oldAccount)}...`);
+            return ConfigurationUtils.toConfigAccount(oldAccount);
+        }
+        if (newAccount) {
+            this.logger.info(`${getAccountLog(newAccount)} has been provided`);
+            return ConfigurationUtils.toConfigAccount(newAccount);
+        }
+
+        const generateErrorMessage = this.resolveGenerateErrorMessage(keyName, privateKeySecurityMode);
+
+        const account = await this.accountResolver.resolveAccount(
+            networkType,
+            newProvidedAccount || oldStoredAccount,
+            keyName,
+            nodeName,
+            'initialization',
+            generateErrorMessage,
+        );
+        return ConfigurationUtils.toConfigAccount(account);
+    }
+}

--- a/src/service/AnnounceService.ts
+++ b/src/service/AnnounceService.ts
@@ -42,6 +42,7 @@ import {
 } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { Addresses, ConfigPreset, NodeAccount, NodePreset } from '../model';
+import { AccountResolver } from './AccountResolver';
 import { CommandUtils } from './CommandUtils';
 import { KeyName } from './ConfigService';
 import { TransactionUtils } from './TransactionUtils';
@@ -63,7 +64,7 @@ export interface TransactionFactory {
 }
 
 export class AnnounceService {
-    constructor(private readonly logger: Logger) {}
+    constructor(private readonly logger: Logger, private readonly accountResolver: AccountResolver) {}
 
     private static onProcessListener = () => {
         process.on('SIGINT', () => {
@@ -225,16 +226,13 @@ export class AnnounceService {
                     }
                 }
 
-                return Account.createFromPrivateKey(
-                    await CommandUtils.resolvePrivateKey(
-                        this.logger,
-                        networkType,
-                        nodeAccount.main,
-                        KeyName.Main,
-                        nodeAccount.name,
-                        'signing a transaction',
-                    ),
+                return this.accountResolver.resolveAccount(
                     networkType,
+                    nodeAccount.main,
+                    KeyName.Main,
+                    nodeAccount.name,
+                    'signing a transaction',
+                    'Should not generate!',
                 );
             };
 
@@ -262,17 +260,13 @@ export class AnnounceService {
                     signerAccount = bestCosigner; // override with a cosigner when multisig
                     requiredCosignatures = multisigAccountInfo.minApproval;
                 } else {
-                    // ask for serviceProviderAccount private key
-                    signerAccount = Account.createFromPrivateKey(
-                        await CommandUtils.resolvePrivateKey(
-                            this.logger,
-                            networkType,
-                            serviceProviderPublicAccount,
-                            KeyName.ServiceProvider,
-                            '',
-                            'signing a transaction',
-                        ),
+                    signerAccount = await this.accountResolver.resolveAccount(
                         networkType,
+                        serviceProviderPublicAccount,
+                        KeyName.ServiceProvider,
+                        undefined,
+                        'signing a transaction',
+                        'Should not generate!',
                     );
                 }
                 const mainMultisigAccountInfo = await TransactionUtils.getMultisigAccount(repositoryFactory, mainAccount.address);

--- a/src/service/BootstrapAccountResolver.ts
+++ b/src/service/BootstrapAccountResolver.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { prompt } from 'inquirer';
+import { Account, NetworkType, PublicAccount } from 'symbol-sdk';
+import { AccountResolver, CertificatePair, CommandUtils, KeyName, KnownError, Logger } from '../';
+
+/**
+ * Prompt ready implementation of the account resolver.
+ */
+export class BootstrapAccountResolver implements AccountResolver {
+    constructor(private readonly logger: Logger) {}
+
+    public async resolveAccount(
+        networkType: NetworkType,
+        account: CertificatePair | undefined,
+        keyName: KeyName,
+        nodeName: string,
+        operationDescription: string,
+        generateErrorMessage: string | undefined,
+    ): Promise<Account> {
+        if (!account) {
+            if (generateErrorMessage) {
+                throw new KnownError(generateErrorMessage);
+            }
+            this.logger.info(`Generating ${keyName} account...`);
+            return Account.generateNewAccount(networkType);
+        }
+
+        if (!account.privateKey) {
+            while (true) {
+                this.logger.info('');
+                this.logger.info(`${keyName} private key is required when ${operationDescription}.`);
+                const address = PublicAccount.createFromPublicKey(account.publicKey, networkType).address.plain();
+                const nodeDescription = nodeName === '' ? `of` : `of the Node's '${nodeName}'`;
+                const responses = await prompt([
+                    {
+                        name: 'value',
+                        message: `Enter the 64 HEX private key ${nodeDescription} ${keyName} account with Address: ${address} and Public Key: ${account.publicKey}:`,
+                        type: 'password',
+                        mask: '*',
+                        validate: CommandUtils.isValidPrivateKey,
+                    },
+                ]);
+                const privateKey = responses.value === '' ? undefined : responses.value.toUpperCase();
+                if (!privateKey) {
+                    this.logger.info('Please provide the private key.');
+                } else {
+                    const enteredAccount = Account.createFromPrivateKey(privateKey, networkType);
+                    if (enteredAccount.publicKey.toUpperCase() !== account.publicKey.toUpperCase()) {
+                        this.logger.info(
+                            `Invalid private key. Expected address is ${address} but you provided the private key for address ${enteredAccount.address.plain()}.\n`,
+                        );
+                        this.logger.info(`Please re-enter private key.`);
+                    } else {
+                        account.privateKey = privateKey;
+                        return Account.createFromPrivateKey(privateKey, networkType);
+                    }
+                }
+            }
+        }
+        return Account.createFromPrivateKey(account.privateKey, networkType);
+    }
+}

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -26,6 +26,7 @@ import { Constants } from './Constants';
 import { FileSystemService } from './FileSystemService';
 import { RuntimeService } from './RuntimeService';
 import { Utils } from './Utils';
+import { AccountResolver, BootstrapUtils, KeyName } from './';
 
 export interface CertificateParams {
     readonly target: string;
@@ -118,21 +119,21 @@ export class CertificateService {
         const copyFrom = join(Constants.ROOT_FOLDER, 'config', 'cert');
         const networkType = presetData.networkType;
 
-        const mainAccountPrivateKey = await CommandUtils.resolvePrivateKey(
-            this.logger,
+        const mainAccount = await this.accountResolver.resolveAccount(
             networkType,
             providedCertificates.main,
             KeyName.Main,
             name,
             'generating the server CA certificates',
+            'Should not generate!',
         );
-        const transportPrivateKey = await CommandUtils.resolvePrivateKey(
-            this.logger,
+        const transportAccount = await this.accountResolver.resolveAccount(
             networkType,
             providedCertificates.transport,
             KeyName.Transport,
             name,
             'generating the server Node certificates',
+            'Should not generate!',
         );
 
         if (!renew) {

--- a/src/service/CommandUtils.ts
+++ b/src/service/CommandUtils.ts
@@ -19,10 +19,7 @@ import { textSync } from 'figlet';
 import { prompt } from 'inquirer';
 import { Convert, PublicAccount } from 'symbol-sdk';
 import { Logger, LoggerFactory, LogType } from '../logger';
-import { CertificatePair } from '../model';
-import { KeyName } from './ConfigService';
 import { Constants } from './Constants';
-import { BootstrapUtils } from './BootstrapUtils';
 
 export class CommandUtils {
     public static passwordPromptDefaultMessage = `Enter the password used to encrypt and decrypt custom presets, addresses.yml, and preset.yml files. When providing a password, private keys will be encrypted. Keep this password in a secure place!`;

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -18,24 +18,10 @@ import * as _ from 'lodash';
 import { join } from 'path';
 import { Account, PublicAccount } from 'symbol-sdk';
 import { Logger } from '../logger';
-import {
-    Addresses,
-    ConfigAccount,
-    ConfigPreset,
-    CustomPreset,
-    MosaicAccounts,
-    NodeAccount,
-    NodePreset,
-    PrivateKeySecurityMode,
-} from '../model';
-import { BootstrapUtils, KnownError, Migration, Password } from './BootstrapUtils';
-import { CommandUtils } from './CommandUtils';
-import { Assembly, defaultAssembly, KeyName } from './ConfigService';
-import { Constants } from './Constants';
-import { CryptoUtils } from './CryptoUtils';
 import { Addresses, ConfigAccount, ConfigPreset, CustomPreset, NodePreset } from '../model';
 import { BootstrapUtils, KnownError, Password } from './BootstrapUtils';
 import { Assembly, defaultAssembly } from './ConfigService';
+import { Constants } from './Constants';
 import { MigrationService } from './MigrationService';
 
 /**

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -37,8 +37,8 @@ import { AddressesService } from './AddressesService';
 import { BootstrapUtils, KnownError, Password } from './BootstrapUtils';
 import { CertificateService } from './CertificateService';
 import { ConfigLoader } from './ConfigLoader';
-import { Constants } from './Constants';
 import { ConfigurationUtils } from './ConfigurationUtils';
+import { Constants } from './Constants';
 import { CryptoUtils } from './CryptoUtils';
 import { FileSystemService } from './FileSystemService';
 import { NemgenService } from './NemgenService';
@@ -331,7 +331,12 @@ export class ConfigService {
                     main: account.main,
                     transport: account.transport,
                 };
-                return new CertificateService(this.logger, this.params.accountResolver, this.params).run(presetData, account.name, providedCertificates, false);
+                return new CertificateService(this.logger, this.params.accountResolver, this.params).run(
+                    presetData,
+                    account.name,
+                    providedCertificates,
+                    false,
+                );
             }),
         );
     }

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -19,7 +19,6 @@ import { copyFileSync, existsSync } from 'fs';
 import * as _ from 'lodash';
 import { join } from 'path';
 import {
-    Account,
     AccountKeyLinkTransaction,
     Convert,
     Deadline,
@@ -33,11 +32,13 @@ import {
 } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { Addresses, ConfigPreset, CustomPreset, GatewayConfigPreset, NodeAccount, PeerInfo } from '../model';
+import { AccountResolver, DefaultAccountResolver } from './AccountResolver';
+import { AddressesService } from './AddressesService';
 import { BootstrapUtils, KnownError, Password } from './BootstrapUtils';
 import { CertificateService } from './CertificateService';
-import { CommandUtils } from './CommandUtils';
 import { ConfigLoader } from './ConfigLoader';
 import { Constants } from './Constants';
+import { ConfigurationUtils } from './ConfigurationUtils';
 import { CryptoUtils } from './CryptoUtils';
 import { FileSystemService } from './FileSystemService';
 import { NemgenService } from './NemgenService';
@@ -72,7 +73,6 @@ export enum KeyName {
     Transport = 'Transport',
     Voting = 'Voting',
     VRF = 'VRF',
-    NemesisSigner = 'Nemesis Signer',
     NemesisAccount = 'Nemesis Account',
     ServiceProvider = 'Service Provider',
 }
@@ -90,6 +90,7 @@ export interface ConfigParams extends VotingParams, ReportParams {
     assembly?: string;
     customPreset?: string;
     customPresetObject?: CustomPreset;
+    accountResolver: AccountResolver;
 }
 
 export interface ConfigResult {
@@ -106,13 +107,16 @@ export class ConfigService {
         reset: false,
         upgrade: false,
         user: Constants.CURRENT_USER,
+        accountResolver: new DefaultAccountResolver(),
     };
     private readonly configLoader: ConfigLoader;
     private readonly fileSystemService: FileSystemService;
+    private readonly addressesService: AddressesService;
 
     constructor(private readonly logger: Logger, private readonly params: ConfigParams) {
         this.configLoader = new ConfigLoader(logger);
         this.fileSystemService = new FileSystemService(logger);
+        this.addressesService = new AddressesService(logger, params.accountResolver);
     }
 
     public resolveConfigPreset(password: Password): ConfigPreset {
@@ -167,7 +171,7 @@ export class ConfigService {
             }
 
             const presetData: ConfigPreset = this.resolveCurrentPresetData(oldPresetData, password);
-            const addresses = await this.configLoader.generateRandomConfiguration(oldAddresses, oldPresetData, presetData);
+            const addresses = await this.addressesService.resolveAddresses(oldAddresses, oldPresetData, presetData);
 
             const privateKeySecurityMode = CryptoUtils.getPrivateKeySecurityMode(presetData.privateKeySecurityMode);
             await this.fileSystemService.mkdir(target);
@@ -244,7 +248,7 @@ export class ConfigService {
         const target = this.params.target;
         const nemesisSeedFolder = this.fileSystemService.getTargetNemesisFolder(target, false, 'seed');
         await this.fileSystemService.mkdir(nemesisSeedFolder);
-        if (ConfigLoader.shouldCreateNemesis(presetData)) {
+        if (ConfigurationUtils.shouldCreateNemesis(presetData)) {
             if (isUpgrade) {
                 this.logger.info('Nemesis data cannot be generated when upgrading...');
             } else {
@@ -308,7 +312,7 @@ export class ConfigService {
                 },
                 metadata: {
                     name: nodePresetData.friendlyName || '',
-                    roles: ConfigLoader.resolveRoles(nodePresetData),
+                    roles: ConfigurationUtils.resolveRoles(nodePresetData),
                 },
             };
         });
@@ -327,7 +331,7 @@ export class ConfigService {
                     main: account.main,
                     transport: account.transport,
                 };
-                return new CertificateService(this.logger, this.params).run(presetData, account.name, providedCertificates, false);
+                return new CertificateService(this.logger, this.params.accountResolver, this.params).run(presetData, account.name, providedCertificates, false);
             }),
         );
     }
@@ -349,36 +353,40 @@ export class ConfigService {
 
         const nodePreset = (presetData.nodes || [])[index];
 
-        const harvesterSigningPrivateKey = nodePreset.harvesting
-            ? await CommandUtils.resolvePrivateKey(
-                  this.logger,
+        const harvestingKeyName = account.remote ? KeyName.Remote : KeyName.Main;
+        const harvestingAccount = account.remote || account.main;
+        const harvesterSigningAccount = nodePreset.harvesting
+            ? await this.params.accountResolver.resolveAccount(
                   presetData.networkType,
-                  account.remote || account.main,
-                  account.remote ? KeyName.Remote : KeyName.Main,
+                  harvestingAccount,
+                  harvestingKeyName,
                   account.name,
                   'storing the harvesterSigningPrivateKey in the server properties',
+                  'Should not generate!',
               )
-            : '';
-        const harvesterVrfPrivateKey = await CommandUtils.resolvePrivateKey(
-            this.logger,
-            presetData.networkType,
-            account.vrf,
-            KeyName.VRF,
-            account.name,
-            'storing the harvesterVrfPrivateKey in the server properties',
-        );
+            : undefined;
+        const harvesterVrf = nodePreset.harvesting
+            ? await this.params.accountResolver.resolveAccount(
+                  presetData.networkType,
+                  account.vrf,
+                  KeyName.VRF,
+                  account.name,
+                  'storing the harvesterVrfPrivateKey in the server properties',
+                  'Should not generate!',
+              )
+            : undefined;
 
         const beneficiaryAddress = nodePreset.beneficiaryAddress || presetData.beneficiaryAddress;
         const generatedContext = {
             name: name,
             friendlyName: nodePreset?.friendlyName || account.friendlyName,
-            harvesterSigningPrivateKey: harvesterSigningPrivateKey,
-            harvesterVrfPrivateKey: harvesterVrfPrivateKey,
+            harvesterSigningPrivateKey: harvesterSigningAccount?.privateKey || '',
+            harvesterVrfPrivateKey: harvesterVrf?.privateKey || '',
             unfinalizedBlocksDuration: nodePreset.voting
                 ? presetData.votingUnfinalizedBlocksDuration
                 : presetData.nonVotingUnfinalizedBlocksDuration,
             beneficiaryAddress: beneficiaryAddress == undefined ? account.main.address : beneficiaryAddress,
-            roles: ConfigLoader.resolveRoles(nodePreset),
+            roles: ConfigurationUtils.resolveRoles(nodePreset),
         };
         const templateContext: any = { ...presetData, ...generatedContext, ...nodePreset };
         const excludeFiles: string[] = [];
@@ -451,7 +459,7 @@ export class ConfigService {
             nodePreset,
             currentFinalizationEpoch,
             undefined,
-            ConfigLoader.shouldCreateNemesis(presetData),
+            ConfigurationUtils.shouldCreateNemesis(presetData),
         );
     }
 
@@ -521,15 +529,14 @@ export class ConfigService {
         }
         const deadline = Deadline.createFromDTO('1');
         const vrf = VrfKeyLinkTransaction.create(deadline, node.vrf.publicKey, LinkAction.Link, presetData.networkType, UInt64.fromUint(0));
-        const mainPrivateKey = await CommandUtils.resolvePrivateKey(
-            this.logger,
+        const account = await this.params.accountResolver.resolveAccount(
             presetData.networkType,
             node.main,
             KeyName.Main,
             node.name,
             'creating the vrf key link transactions',
+            'Should not generate!',
         );
-        const account = Account.createFromPrivateKey(mainPrivateKey, presetData.networkType);
         const signedTransaction = account.sign(vrf, presetData.nemesisGenerationHashSeed);
         return this.storeTransaction(transactionsDirectory, `vrf_${node.name}`, signedTransaction.payload);
     }
@@ -553,15 +560,14 @@ export class ConfigService {
             presetData.networkType,
             UInt64.fromUint(0),
         );
-        const mainPrivateKey = await CommandUtils.resolvePrivateKey(
-            this.logger,
+        const account = await this.params.accountResolver.resolveAccount(
             presetData.networkType,
             node.main,
             KeyName.Main,
             node.name,
             'creating the account link transactions',
+            'Should not generate!',
         );
-        const account = Account.createFromPrivateKey(mainPrivateKey, presetData.networkType);
         const signedTransaction = account.sign(akl, presetData.nemesisGenerationHashSeed);
         return this.storeTransaction(transactionsDirectory, `remote_${node.name}`, signedTransaction.payload);
     }
@@ -572,13 +578,13 @@ export class ConfigService {
         node: NodeAccount,
     ): Promise<Transaction[]> {
         const votingFiles = node.voting || [];
-        const mainPrivateKey = await CommandUtils.resolvePrivateKey(
-            this.logger,
+        const account = await this.params.accountResolver.resolveAccount(
             presetData.networkType,
             node.main,
             KeyName.Main,
             node.name,
             'creating the voting key link transactions',
+            'Should not generate!',
         );
         return Promise.all(
             votingFiles.map(async (votingFile) => {
@@ -592,7 +598,6 @@ export class ConfigService {
                     1,
                     UInt64.fromUint(0),
                 );
-                const account = Account.createFromPrivateKey(mainPrivateKey, presetData.networkType);
                 const signedTransaction = account.sign(voting, presetData.nemesisGenerationHashSeed);
                 return this.storeTransaction(transactionsDirectory, `voting_${node.name}`, signedTransaction.payload);
             }),

--- a/src/service/ConfigurationUtils.ts
+++ b/src/service/ConfigurationUtils.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { Account, NetworkType, PublicAccount } from 'symbol-sdk';
 import { ConfigAccount, ConfigPreset, NodePreset } from '../model';
 import { BootstrapUtils } from './BootstrapUtils';
+import { Constants } from './Constants';
 
 /**
  * Utility class for bootstrap configuration related methods.
@@ -75,8 +76,7 @@ export class ConfigurationUtils {
         return (
             presetData.nemesis &&
             !presetData.nemesisSeedFolder &&
-            (BootstrapUtils.isYmlFile(presetData.preset) ||
-                !existsSync(join(BootstrapUtils.ROOT_FOLDER, 'presets', presetData.preset, 'seed')))
+            (BootstrapUtils.isYmlFile(presetData.preset) || !existsSync(join(Constants.ROOT_FOLDER, 'presets', presetData.preset, 'seed')))
         );
     }
 }

--- a/src/service/ConfigurationUtils.ts
+++ b/src/service/ConfigurationUtils.ts
@@ -1,0 +1,82 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { Account, NetworkType, PublicAccount } from 'symbol-sdk';
+import { ConfigAccount, ConfigPreset, NodePreset } from '../model';
+import { BootstrapUtils } from './BootstrapUtils';
+
+/**
+ * Utility class for bootstrap configuration related methods.
+ */
+export class ConfigurationUtils {
+    public static toConfigAccountFomKeys(
+        networkType: NetworkType,
+        publicKey: string | undefined,
+        privateKey: string | undefined,
+    ): ConfigAccount | undefined {
+        const account = this.toAccount(networkType, publicKey, privateKey);
+        if (!account) {
+            return undefined;
+        }
+        return this.toConfigAccount(account);
+    }
+
+    public static toAccount(
+        networkType: NetworkType,
+        publicKey: string | undefined,
+        privateKey: string | undefined,
+    ): PublicAccount | Account | undefined {
+        if (privateKey) {
+            const account = Account.createFromPrivateKey(privateKey, networkType);
+            if (publicKey && account.publicKey.toUpperCase() != publicKey.toUpperCase()) {
+                throw new Error('Invalid provided public key/private key!');
+            }
+            return account;
+        }
+        if (publicKey) {
+            return PublicAccount.createFromPublicKey(publicKey, networkType);
+        }
+        return undefined;
+    }
+
+    public static toConfigAccount(account: PublicAccount | Account): ConfigAccount {
+        // isntanceof doesn't work when loaded in multiple libraries.
+        //https://stackoverflow.com/questions/59265098/instanceof-not-work-correctly-in-typescript-library-project
+        if (account.constructor.name === Account.name) {
+            return {
+                privateKey: (account as Account).privateKey,
+                publicKey: account.publicKey,
+                address: account.address.plain(),
+            };
+        }
+        return {
+            publicKey: account.publicKey,
+            address: account.address.plain(),
+        };
+    }
+
+    public static resolveRoles(nodePreset: NodePreset): string {
+        if (nodePreset.roles) {
+            return nodePreset.roles;
+        }
+        const roles: string[] = [];
+        if (nodePreset.syncsource) {
+            roles.push('Peer');
+        }
+        if (nodePreset.api) {
+            roles.push('Api');
+        }
+        if (nodePreset.voting) {
+            roles.push('Voting');
+        }
+        return roles.join(',');
+    }
+
+    public static shouldCreateNemesis(presetData: ConfigPreset): boolean {
+        return (
+            presetData.nemesis &&
+            !presetData.nemesisSeedFolder &&
+            (BootstrapUtils.isYmlFile(presetData.preset) ||
+                !existsSync(join(BootstrapUtils.ROOT_FOLDER, 'presets', presetData.preset, 'seed')))
+        );
+    }
+}

--- a/src/service/LinkService.ts
+++ b/src/service/LinkService.ts
@@ -27,13 +27,12 @@ import {
 } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { Addresses, ConfigPreset, NodeAccount } from '../model';
+import { AccountResolver, BootstrapAccountResolver } from '../service';
 import { AnnounceService, TransactionFactory } from './AnnounceService';
 import { ConfigLoader } from './ConfigLoader';
 import { Constants } from './Constants';
 import { VotingKeyAccount } from './VotingUtils';
 
-import { AccountResolver, AnnounceService, BootstrapAccountResolver, ConfigLoader, TransactionFactory, VotingKeyAccount } from '../service';
-import { BootstrapUtils } from './BootstrapUtils';
 /**
  * params necessary to announce link transactions network.
  */

--- a/src/service/LinkService.ts
+++ b/src/service/LinkService.ts
@@ -32,6 +32,8 @@ import { ConfigLoader } from './ConfigLoader';
 import { Constants } from './Constants';
 import { VotingKeyAccount } from './VotingUtils';
 
+import { AccountResolver, AnnounceService, BootstrapAccountResolver, ConfigLoader, TransactionFactory, VotingKeyAccount } from '../service';
+import { BootstrapUtils } from './BootstrapUtils';
 /**
  * params necessary to announce link transactions network.
  */
@@ -46,6 +48,7 @@ export type LinkParams = {
     customPreset?: string;
     serviceProviderPublicKey?: string;
     removeOldLinked?: boolean; //TEST ONLY!
+    accountResolver?: AccountResolver;
 };
 
 export type KeyAccount = { publicKey: string };
@@ -86,8 +89,8 @@ export class LinkService implements TransactionFactory {
         const addresses = passedAddresses ?? this.configLoader.loadExistingAddresses(this.params.target, this.params.password);
         const customPreset = this.configLoader.loadCustomPreset(this.params.customPreset, this.params.password);
         this.logger.info(`${this.params.unlink ? 'Unlinking' : 'Linking'} nodes`);
-
-        await new AnnounceService(this.logger).announce(
+        const accountResolver = this.params.accountResolver || new BootstrapAccountResolver(this.logger);
+        await new AnnounceService(this.logger, accountResolver).announce(
             this.params.url,
             this.params.maxFee,
             this.params.useKnownRestGateways,

--- a/src/service/MigrationService.ts
+++ b/src/service/MigrationService.ts
@@ -1,0 +1,53 @@
+import { Account, NetworkType } from 'symbol-sdk';
+import { Logger } from '../logger';
+import { Addresses } from '../model';
+import { BootstrapUtils, Migration } from './BootstrapUtils';
+import { ConfigurationUtils } from './ConfigurationUtils';
+
+export class MigrationService {
+    constructor(private readonly logger: Logger) {}
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    public migrateAddresses(addresses: any): Addresses {
+        const addressesFileName = 'addresses.yml';
+        const networkType = addresses.networkType;
+        if (!networkType) {
+            throw new Error(`networkType must exist on current ${addressesFileName}`);
+        }
+        const migrations = this.getAddressesMigration(networkType);
+        return BootstrapUtils.migrate(this.logger, addressesFileName, addresses, migrations);
+    }
+
+    public getAddressesMigration(networkType: NetworkType): Migration[] {
+        return [
+            {
+                description: 'Key names migration',
+
+                migrate(from: any): any {
+                    (from.nodes || []).forEach((nodeAddresses: any): any => {
+                        if (nodeAddresses.signing) {
+                            nodeAddresses.main = nodeAddresses.signing;
+                        } else {
+                            if (nodeAddresses.ssl) {
+                                nodeAddresses.main = ConfigurationUtils.toConfigAccount(
+                                    Account.createFromPrivateKey(nodeAddresses.ssl.privateKey, networkType),
+                                );
+                            }
+                        }
+                        nodeAddresses.transport = ConfigurationUtils.toConfigAccountFomKeys(
+                            networkType,
+                            nodeAddresses?.node?.publicKey,
+                            nodeAddresses?.node?.privateKey,
+                        );
+                        if (!nodeAddresses.transport) {
+                            nodeAddresses.transport = ConfigurationUtils.toConfigAccount(Account.generateNewAccount(networkType));
+                        }
+                        delete nodeAddresses.node;
+                        delete nodeAddresses.signing;
+                        delete nodeAddresses.ssl;
+                    });
+                    return from;
+                },
+            },
+        ];
+    }
+}

--- a/src/service/ModifyMultisigService.ts
+++ b/src/service/ModifyMultisigService.ts
@@ -25,7 +25,10 @@ import {
 } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { Addresses, ConfigPreset } from '../model';
+import { AccountResolver } from './AccountResolver';
 import { AnnounceService, TransactionFactory, TransactionFactoryParams } from './AnnounceService';
+import { BootstrapAccountResolver } from './BootstrapAccountResolver';
+import { BootstrapUtils } from './BootstrapUtils';
 import { ConfigLoader } from './ConfigLoader';
 import { Constants } from './Constants';
 import { TransactionUtils } from './TransactionUtils';
@@ -46,6 +49,7 @@ export type ModifyMultisigParams = {
     addressAdditions?: string;
     addressDeletions?: string;
     serviceProviderPublicKey?: string;
+    accountResolver?: AccountResolver;
 };
 
 export class ModifyMultisigService implements TransactionFactory {
@@ -67,8 +71,8 @@ export class ModifyMultisigService implements TransactionFactory {
         const presetData = passedPresetData ?? this.configLoader.loadExistingPresetData(this.params.target, this.params.password);
         const addresses = passedAddresses ?? this.configLoader.loadExistingAddresses(this.params.target, this.params.password);
         const customPreset = this.configLoader.loadCustomPreset(this.params.customPreset, this.params.password);
-
-        await new AnnounceService(this.logger).announce(
+        const accountResolver = this.params.accountResolver || new BootstrapAccountResolver(this.logger);
+        await new AnnounceService(this.logger, accountResolver).announce(
             this.params.url,
             this.params.maxFee,
             this.params.useKnownRestGateways,

--- a/src/service/ModifyMultisigService.ts
+++ b/src/service/ModifyMultisigService.ts
@@ -28,7 +28,6 @@ import { Addresses, ConfigPreset } from '../model';
 import { AccountResolver } from './AccountResolver';
 import { AnnounceService, TransactionFactory, TransactionFactoryParams } from './AnnounceService';
 import { BootstrapAccountResolver } from './BootstrapAccountResolver';
-import { BootstrapUtils } from './BootstrapUtils';
 import { ConfigLoader } from './ConfigLoader';
 import { Constants } from './Constants';
 import { TransactionUtils } from './TransactionUtils';

--- a/src/service/RunService.ts
+++ b/src/service/RunService.ts
@@ -21,6 +21,7 @@ import { NodeStatusEnum } from 'symbol-openapi-typescript-fetch-client';
 import { RepositoryFactoryHttp } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { DockerCompose, DockerComposeService } from '../model';
+import { DefaultAccountResolver } from './AccountResolver';
 import { BootstrapUtils } from './BootstrapUtils';
 import { CertificateService } from './CertificateService';
 import { ConfigLoader } from './ConfigLoader';
@@ -110,7 +111,10 @@ export class RunService {
 
     private async checkCertificates(): Promise<boolean> {
         const presetData = this.configLoader.loadExistingPresetData(this.params.target, false);
-        const service = new CertificateService(this.logger, { target: this.params.target, user: Constants.CURRENT_USER });
+        const service = new CertificateService(this.logger, new DefaultAccountResolver(), {
+            target: this.params.target,
+            user: Constants.CURRENT_USER,
+        });
         const allServicesChecks: Promise<boolean>[] = (presetData.nodes || []).map(async (nodePreset) => {
             const name = nodePreset.name;
             const certFolder = this.fileSystemService.getTargetNodesFolder(this.params.target, false, name, 'cert');

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,6 +1,9 @@
 // created from 'create-ts-index'
 
+export * from './AccountResolver';
+export * from './AddressesService';
 export * from './AnnounceService';
+export * from './BootstrapAccountResolver';
 export * from './BootstrapService';
 export * from './BootstrapUtils';
 export * from './CertificateService';
@@ -8,10 +11,12 @@ export * from './CommandUtils';
 export * from './ComposeService';
 export * from './ConfigLoader';
 export * from './ConfigService';
+export * from './ConfigurationUtils';
 export * from './Constants';
 export * from './CryptoUtils';
 export * from './FileSystemService';
 export * from './LinkService';
+export * from './MigrationService';
 export * from './ModifyMultisigService';
 export * from './NemgenService';
 export * from './OSUtils';

--- a/test/service/AddressesService.test.ts
+++ b/test/service/AddressesService.test.ts
@@ -1,0 +1,299 @@
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { Account, NetworkType } from 'symbol-sdk';
+import { DefaultAccountResolver, KeyName, LoggerFactory, LogType, PrivateKeySecurityMode } from '../../src';
+import { AddressesService } from '../../src/service/AddressesService';
+
+const accountResolver = new DefaultAccountResolver();
+const nodeName = 'node';
+const logger = LoggerFactory.getLogger(LogType.Silent);
+const service = new AddressesService(logger, accountResolver);
+
+describe('', () => {
+    it('should resolveAccount when old and new are different', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = Account.generateNewAccount(networkType);
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            'node',
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+                privateKey: oldAccount.privateKey,
+            },
+            {
+                privateKey: newAccount.privateKey,
+                address: newAccount.address.plain(),
+                publicKey: newAccount.publicKey,
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+            privateKey: newAccount.privateKey,
+        });
+    });
+
+    it('should resolveAccount when old and new are different', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = Account.generateNewAccount(networkType);
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+                privateKey: oldAccount.privateKey,
+            },
+            {
+                privateKey: newAccount.privateKey,
+                address: newAccount.address.plain(),
+                publicKey: newAccount.publicKey,
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+            privateKey: newAccount.privateKey,
+        });
+    });
+
+    it('should resolveAccount when old and new are same', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = oldAccount;
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+                privateKey: oldAccount.privateKey,
+            },
+            {
+                privateKey: newAccount.privateKey,
+                address: newAccount.address.plain(),
+                publicKey: newAccount.publicKey,
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+            privateKey: newAccount.privateKey,
+        });
+    });
+
+    it('should resolveAccount when old and new are same, new no private eky', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = oldAccount;
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+                privateKey: oldAccount.privateKey,
+            },
+            {
+                address: newAccount.address.plain(),
+                publicKey: newAccount.publicKey,
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+            privateKey: newAccount.privateKey,
+        });
+    });
+
+    it('should resolveAccount when old and new are same, old no private key', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = oldAccount;
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+            },
+            {
+                privateKey: newAccount.privateKey,
+                address: newAccount.address.plain(),
+                publicKey: newAccount.publicKey,
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+            privateKey: newAccount.privateKey,
+        });
+    });
+
+    it('should resolveAccount when old and new are same, old private key', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = oldAccount;
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+            },
+            {
+                publicKey: newAccount.publicKey,
+                address: newAccount.address.plain(),
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+        });
+    });
+
+    it('should resolveAccount when old and new are different, no private key new', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const newAccount = Account.generateNewAccount(networkType);
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+                privateKey: oldAccount.privateKey,
+            },
+            {
+                publicKey: newAccount.publicKey,
+                address: newAccount.address.plain(),
+            },
+        );
+        expect(account).deep.eq({
+            publicKey: newAccount.publicKey,
+            address: newAccount.address.plain(),
+        });
+    });
+
+    it('should resolveAccount when old and new are different. No new account', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+                privateKey: oldAccount.privateKey,
+            },
+            undefined,
+        );
+        expect(account).deep.eq({
+            publicKey: oldAccount.publicKey,
+            address: oldAccount.address.plain(),
+            privateKey: oldAccount.privateKey,
+        });
+    });
+
+    it('should resolveAccount when old and new are different. No new account. Old without private', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const oldAccount = Account.generateNewAccount(networkType);
+        const account = await service.resolveAccount(
+            networkType,
+            securityMode,
+            KeyName.Main,
+            nodeName,
+            {
+                publicKey: oldAccount.publicKey,
+                address: oldAccount.address.plain(),
+            },
+            undefined,
+        );
+        expect(account).deep.eq({
+            publicKey: oldAccount.publicKey,
+            address: oldAccount.address.plain(),
+        });
+    });
+
+    it('should resolveAccount brand new', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.ENCRYPT;
+        const account = await service.resolveAccount(networkType, securityMode, KeyName.Main, nodeName, undefined, undefined);
+        expect(account.address).not.undefined;
+        expect(account.privateKey).not.undefined;
+        expect(account.privateKey).not.undefined;
+    });
+
+    it('should resolveAccount brand new on remote', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT;
+        const account = await service.resolveAccount(networkType, securityMode, KeyName.Remote, nodeName, undefined, undefined);
+        expect(account.address).not.undefined;
+        expect(account.privateKey).not.undefined;
+        expect(account.privateKey).not.undefined;
+    });
+
+    it('should resolveAccount brand new on voting', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN;
+        const account = await service.resolveAccount(networkType, securityMode, KeyName.Voting, nodeName, undefined, undefined);
+        expect(account.address).not.undefined;
+        expect(account.privateKey).not.undefined;
+        expect(account.privateKey).not.undefined;
+    });
+
+    it('should resolveAccount raise error new', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN;
+
+        try {
+            await service.resolveAccount(networkType, securityMode, KeyName.Main, nodeName, undefined, undefined);
+            expect(false).eq(true);
+        } catch (e) {
+            expect(e.message).eq(
+                "Account Main cannot be generated when Private Key Security Mode is PROMPT_MAIN. Account won't be stored anywhere!. Please use ENCRYPT, or provider your Main account with custom presets!",
+            );
+        }
+    });
+
+    it('should resolveAccount raise error new', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT;
+        expect(async () => await service.resolveAccount(networkType, securityMode, KeyName.Transport, nodeName, undefined, undefined))
+            .throw;
+    });
+
+    it('should resolveAccount raise error new', async () => {
+        const networkType = NetworkType.TEST_NET;
+        const securityMode = PrivateKeySecurityMode.PROMPT_ALL;
+        expect(async () => await service.resolveAccount(networkType, securityMode, KeyName.Remote, nodeName, undefined, undefined)).throw;
+    });
+});

--- a/test/service/AnnounceService.test.ts
+++ b/test/service/AnnounceService.test.ts
@@ -32,15 +32,15 @@ import {
     TransferTransaction,
     UInt64,
 } from 'symbol-sdk';
-import { AccountResolver, Assembly, BootstrapUtils, DefaultAccountResolver, LoggerFactory, LogType } from '../../src';
 import {
+    AccountResolver,
     AnnounceService,
     Assembly,
     BootstrapService,
     BootstrapUtils,
-    CommandUtils,
     ConfigService,
     Constants,
+    DefaultAccountResolver,
     LoggerFactory,
     LogType,
     Preset,

--- a/test/service/BootstrapServce.test.ts
+++ b/test/service/BootstrapServce.test.ts
@@ -16,9 +16,7 @@
 
 import { expect } from 'chai';
 import 'mocha';
-import { Assembly, BootstrapService, Constants, LoggerFactory, LogType, Preset, StartParams } from '../../src';
-import { Assembly, BootstrapUtils, DefaultAccountResolver, LoggerFactory, LogType } from '../../src';
-import { BootstrapService, Preset, StartParams } from '../../src/service';
+import { Assembly, BootstrapService, Constants, DefaultAccountResolver, LoggerFactory, LogType, Preset, StartParams } from '../../src';
 
 const logger = LoggerFactory.getLogger(LogType.Silent);
 describe('BootstrapService', () => {

--- a/test/service/BootstrapServce.test.ts
+++ b/test/service/BootstrapServce.test.ts
@@ -17,6 +17,8 @@
 import { expect } from 'chai';
 import 'mocha';
 import { Assembly, BootstrapService, Constants, LoggerFactory, LogType, Preset, StartParams } from '../../src';
+import { Assembly, BootstrapUtils, DefaultAccountResolver, LoggerFactory, LogType } from '../../src';
+import { BootstrapService, Preset, StartParams } from '../../src/service';
 
 const logger = LoggerFactory.getLogger(LogType.Silent);
 describe('BootstrapService', () => {
@@ -29,6 +31,7 @@ describe('BootstrapService', () => {
             reset: true,
             upgrade: false,
             timeout: 60000 * 5,
+            accountResolver: new DefaultAccountResolver(),
             target: 'target/tests/BootstrapService.standard',
             detached: true,
             user: 'current',
@@ -51,6 +54,7 @@ describe('BootstrapService', () => {
             reset: true,
             upgrade: false,
             timeout: 60000 * 5,
+            accountResolver: new DefaultAccountResolver(),
             target: 'target/tests/BootstrapService.testnet',
             detached: true,
             user: 'current',

--- a/test/service/BootstrapUtils.test.ts
+++ b/test/service/BootstrapUtils.test.ts
@@ -20,9 +20,14 @@ import 'mocha';
 import { it } from 'mocha';
 import { totalmem } from 'os';
 import { Account, NetworkType } from 'symbol-sdk';
+import { ConfigurationUtils, LoggerFactory, LogType } from '../../src';
 import { ConfigAccount } from '../../src/model';
 import { BootstrapUtils, ConfigLoader, CryptoUtils } from '../../src/service';
 
+import { BootstrapUtils, CryptoUtils } from '../../src/service';
+import assert = require('assert');
+import nock = require('nock');
+const logger = LoggerFactory.getLogger(LogType.Silent);
 describe('BootstrapUtils', () => {
     it('BootstrapUtils generate random', async () => {
         const networkType = NetworkType.TEST_NET;
@@ -31,7 +36,7 @@ describe('BootstrapUtils', () => {
 
         for (let i = 0; i < 10; i++) {
             console.log();
-            const account = ConfigLoader.toConfig(Account.generateNewAccount(networkType));
+            const account = ConfigurationUtils.toConfigAccount(Account.generateNewAccount(networkType));
             balances.push({ ...account, balance: 1000000 });
         }
         console.log(BootstrapUtils.toYaml({ nemesisBalances: balances }));

--- a/test/service/BootstrapUtils.test.ts
+++ b/test/service/BootstrapUtils.test.ts
@@ -20,14 +20,10 @@ import 'mocha';
 import { it } from 'mocha';
 import { totalmem } from 'os';
 import { Account, NetworkType } from 'symbol-sdk';
-import { ConfigurationUtils, LoggerFactory, LogType } from '../../src';
+import { ConfigurationUtils } from '../../src';
 import { ConfigAccount } from '../../src/model';
-import { BootstrapUtils, ConfigLoader, CryptoUtils } from '../../src/service';
-
 import { BootstrapUtils, CryptoUtils } from '../../src/service';
-import assert = require('assert');
-import nock = require('nock');
-const logger = LoggerFactory.getLogger(LogType.Silent);
+
 describe('BootstrapUtils', () => {
     it('BootstrapUtils generate random', async () => {
         const networkType = NetworkType.TEST_NET;

--- a/test/service/CertificateService.test.ts
+++ b/test/service/CertificateService.test.ts
@@ -27,6 +27,7 @@ import {
     CertificateService,
     ConfigLoader,
     Constants,
+    DefaultAccountResolver,
     FileSystemService,
     NodeCertificates,
     Preset,
@@ -35,6 +36,7 @@ import {
 
 const logger = LoggerFactory.getLogger(LogType.Silent);
 const runtimeService = new RuntimeService(logger);
+const accountResolver = new DefaultAccountResolver();
 const fileSystemService = new FileSystemService(logger);
 describe('CertificateService', () => {
     const target = 'target/tests/CertificateService.test';
@@ -89,7 +91,10 @@ describe('CertificateService', () => {
     it('createCertificates', async () => {
         fileSystemService.deleteFolder(target);
 
-        const service = new CertificateService(logger, { target: target, user: await runtimeService.getDockerUserGroup() });
+        const service = new CertificateService(logger, accountResolver, {
+            target: target,
+            user: await runtimeService.getDockerUserGroup(),
+        });
         await service.run(presetData, name, keys, false, target, randomSerial);
 
         const expectedMetadata: CertificateMetadata = {
@@ -106,7 +111,10 @@ describe('CertificateService', () => {
         const nodeCertificateExpirationInDays = presetData.nodeCertificateExpirationInDays;
         const caCertificateExpirationInDays = presetData.caCertificateExpirationInDays;
 
-        const service = new CertificateService(logger, { target: target, user: await runtimeService.getDockerUserGroup() });
+        const service = new CertificateService(logger, accountResolver, {
+            target: target,
+            user: await runtimeService.getDockerUserGroup(),
+        });
         await service.run(presetData, name, keys, false, target, randomSerial);
 
         async function willExpire(certificateFileName: string, certificateExpirationWarningInDays: number): Promise<boolean> {
@@ -129,8 +137,10 @@ describe('CertificateService', () => {
     it('create and renew certificates', async () => {
         const target = 'target/tests/CertificateService.test';
         fileSystemService.deleteFolder(target);
-        const service = new CertificateService(logger, { target: target, user: await runtimeService.getDockerUserGroup() });
-
+        const service = new CertificateService(logger, accountResolver, {
+            target: target,
+            user: await runtimeService.getDockerUserGroup(),
+        });
         async function getCertFile(certificateFileName: string): Promise<string> {
             return readFileSync(join(target, certificateFileName), 'utf-8');
         }

--- a/test/service/ConfigLoader.test.ts
+++ b/test/service/ConfigLoader.test.ts
@@ -16,21 +16,8 @@
 
 import { expect } from 'chai';
 import 'mocha';
-import { Assembly, LoggerFactory, LogType } from '../../src';
+import { Assembly, Constants, LoggerFactory, LogType } from '../../src';
 import { BootstrapUtils, ConfigLoader, Preset } from '../../src/service';
-import { Account, NetworkType } from 'symbol-sdk';
-import {
-    Assembly,
-    BootstrapUtils,
-    ConfigAccount,
-    ConfigLoader,
-    Constants,
-    KeyName,
-    LoggerFactory,
-    LogType,
-    Preset,
-    PrivateKeySecurityMode,
-} from '../../src';
 
 const logger = LoggerFactory.getLogger(LogType.Silent);
 

--- a/test/service/ConfigLoader.test.ts
+++ b/test/service/ConfigLoader.test.ts
@@ -16,6 +16,8 @@
 
 import { expect } from 'chai';
 import 'mocha';
+import { Assembly, LoggerFactory, LogType } from '../../src';
+import { BootstrapUtils, ConfigLoader, Preset } from '../../src/service';
 import { Account, NetworkType } from 'symbol-sdk';
 import {
     Assembly,
@@ -31,20 +33,10 @@ import {
 } from '../../src';
 
 const logger = LoggerFactory.getLogger(LogType.Silent);
-class ConfigLoaderMocked extends ConfigLoader {
-    public generateAccount = (
-        networkType: NetworkType,
-        securityMode: PrivateKeySecurityMode,
-        keyName: KeyName,
-        oldAccount: ConfigAccount | undefined,
-        privateKey: string | undefined,
-        publicKey: string | undefined,
-    ): ConfigAccount => super.generateAccount(networkType, securityMode, keyName, oldAccount, privateKey || 'a'.repeat(64), publicKey);
-}
 
 describe('ConfigLoader', () => {
     it('ConfigLoader loadPresetData no preset', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         try {
             await configLoader.createPresetData({
                 workingDir: Constants.defaultWorkingDir,
@@ -63,7 +55,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData testnet no assembly', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         try {
             await configLoader.createPresetData({
                 workingDir: Constants.defaultWorkingDir,
@@ -82,7 +74,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData invalid assembly file', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         try {
             await configLoader.createPresetData({
                 workingDir: Constants.defaultWorkingDir,
@@ -101,7 +93,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData invalid preset file', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         try {
             await configLoader.createPresetData({
                 workingDir: Constants.defaultWorkingDir,
@@ -118,7 +110,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData bootstrap no assembly', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const presetData = await configLoader.createPresetData({
             workingDir: Constants.defaultWorkingDir,
             preset: Preset.bootstrap,
@@ -132,7 +124,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData testnet assembly', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const presetData = await configLoader.createPresetData({
             workingDir: Constants.defaultWorkingDir,
             preset: Preset.testnet,
@@ -147,7 +139,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData testnet assembly using external files', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const presetData = await configLoader.createPresetData({
             workingDir: Constants.defaultWorkingDir,
             preset: 'presets/testnet/network.yml',
@@ -162,7 +154,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader custom maxUnlockedAccounts', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const originalPresetData = await configLoader.createPresetData({
             workingDir: Constants.defaultWorkingDir,
             preset: Preset.testnet,
@@ -235,7 +227,7 @@ describe('ConfigLoader', () => {
     });
 
     it('mergePreset', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         expect(
             configLoader.mergePresets(
                 { maxUnlockedAccounts: 1, inflation: { a: 1, c: 1, d: 1 } },
@@ -247,7 +239,7 @@ describe('ConfigLoader', () => {
     });
 
     it('mergePreset with node', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const merged = configLoader.mergePresets(
             {
                 maxUnlockedAccounts: 1,
@@ -272,7 +264,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader custom maxUnlockedAccounts', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const originalPresetData = await configLoader.createPresetData({
             workingDir: Constants.defaultWorkingDir,
             preset: Preset.testnet,
@@ -345,7 +337,7 @@ describe('ConfigLoader', () => {
     });
 
     it('mergePreset', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         expect(
             configLoader.mergePresets(
                 { maxUnlockedAccounts: 1, inflation: { a: 1, c: 1, d: 1 } },
@@ -357,7 +349,7 @@ describe('ConfigLoader', () => {
     });
 
     it('mergePreset with node', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const merged = configLoader.mergePresets(
             {
                 maxUnlockedAccounts: 1,
@@ -382,7 +374,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData bootstrap custom', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const presetData = await configLoader.createPresetData({
             workingDir: Constants.defaultWorkingDir,
             preset: Preset.bootstrap,
@@ -398,7 +390,7 @@ describe('ConfigLoader', () => {
     });
 
     it('ConfigLoader loadPresetData bootstrap custom too short!', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         try {
             await configLoader.createPresetData({
                 workingDir: Constants.defaultWorkingDir,
@@ -414,7 +406,7 @@ describe('ConfigLoader', () => {
     });
 
     it('applyIndex', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const context = { $index: 10 };
         expect(configLoader.applyValueTemplate(context, 'hello')).to.be.eq('hello');
         expect(configLoader.applyValueTemplate(context, 'index')).to.be.eq('index');
@@ -427,7 +419,7 @@ describe('ConfigLoader', () => {
     });
 
     it('expandServicesRepeat when repeat 3', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const services = [
             {
                 repeat: 3,
@@ -480,7 +472,7 @@ describe('ConfigLoader', () => {
     });
 
     it('expandServicesRepeat when repeat 0', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const services = [
             {
                 repeat: 0,
@@ -501,7 +493,7 @@ describe('ConfigLoader', () => {
     });
 
     it('expandServicesRepeat when no repeat', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const services = [
             {
                 apiNodeName: 'api-node-{{$index}}',
@@ -533,7 +525,7 @@ describe('ConfigLoader', () => {
     });
 
     it('applyValueTemplate when object', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const value = {
             _info: 'this file contains a list of api-node peers',
             knownPeers: [
@@ -556,7 +548,7 @@ describe('ConfigLoader', () => {
     });
 
     it('applyValueTemplate when array', async () => {
-        const configLoader = new ConfigLoaderMocked(logger);
+        const configLoader = new ConfigLoader(logger);
         const value = [
             {
                 _info: 'this file contains a list of api-node peers',
@@ -578,288 +570,5 @@ describe('ConfigLoader', () => {
 
         expect(configLoader.applyValueTemplate({}, value)).to.be.deep.eq(value);
         expect(configLoader.applyValueTemplate({}, BootstrapUtils.fromYaml(BootstrapUtils.toYaml(value)))).to.be.deep.eq(value);
-    });
-
-    it('should migrated old addresses', () => {
-        const configLoader = new ConfigLoaderMocked(logger);
-        const oldAddresses = BootstrapUtils.loadYaml('./test/addresses/addresses-old.yml', false);
-        const newAddresses = BootstrapUtils.loadYaml('./test/addresses/addresses-new.yml', false);
-        const addresses = configLoader.migrateAddresses(oldAddresses, NetworkType.TEST_NET);
-        expect(addresses).to.be.deep.eq(newAddresses);
-    });
-
-    it('should migrated not migrate new addresses', () => {
-        const configLoader = new ConfigLoaderMocked(logger);
-        const newAddresses = BootstrapUtils.loadYaml('./test/addresses/addresses-new.yml', false);
-        const addresses = configLoader.migrateAddresses(newAddresses, NetworkType.TEST_NET);
-        expect(addresses).to.be.deep.eq(newAddresses);
-    });
-
-    it('should generateAccount when old and new are different', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = Account.generateNewAccount(networkType);
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-                privateKey: oldAccount.privateKey,
-            },
-            newAccount.privateKey,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-            privateKey: newAccount.privateKey,
-        });
-    });
-
-    it('should generateAccount when old and new are different', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = Account.generateNewAccount(networkType);
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-                privateKey: oldAccount.privateKey,
-            },
-            newAccount.privateKey,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-            privateKey: newAccount.privateKey,
-        });
-    });
-
-    it('should generateAccount when old and new are same', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = oldAccount;
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-                privateKey: oldAccount.privateKey,
-            },
-            newAccount.privateKey,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-            privateKey: newAccount.privateKey,
-        });
-    });
-
-    it('should generateAccount when old and new are same, new no private eky', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = oldAccount;
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-                privateKey: oldAccount.privateKey,
-            },
-            undefined,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-            privateKey: newAccount.privateKey,
-        });
-    });
-
-    it('should generateAccount when old and new are same, old no private eky', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = oldAccount;
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-            },
-            newAccount.privateKey,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-            privateKey: newAccount.privateKey,
-        });
-    });
-
-    it('should generateAccount when old and new are same, old private key', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = oldAccount;
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-            },
-            undefined,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-        });
-    });
-
-    it('should generateAccount when old and new are different, no private key new', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const newAccount = Account.generateNewAccount(networkType);
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-                privateKey: oldAccount.privateKey,
-            },
-            undefined,
-            newAccount.publicKey,
-        );
-        expect(account).deep.eq({
-            publicKey: newAccount.publicKey,
-            address: newAccount.address.plain(),
-        });
-    });
-
-    it('should generateAccount when old and new are different. No new account', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-                privateKey: oldAccount.privateKey,
-            },
-            undefined,
-            undefined,
-        );
-        expect(account).deep.eq({
-            publicKey: oldAccount.publicKey,
-            address: oldAccount.address.plain(),
-            privateKey: oldAccount.privateKey,
-        });
-    });
-
-    it('should generateAccount when old and new are different. No new account. Old without private', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const oldAccount = Account.generateNewAccount(networkType);
-        const account = configLoader.generateAccount(
-            networkType,
-            securityMode,
-            KeyName.Main,
-            {
-                publicKey: oldAccount.publicKey,
-                address: oldAccount.address.plain(),
-            },
-            undefined,
-            undefined,
-        );
-        expect(account).deep.eq({
-            publicKey: oldAccount.publicKey,
-            address: oldAccount.address.plain(),
-        });
-    });
-
-    it('should generateAccount brand new', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.ENCRYPT;
-        const account = configLoader.generateAccount(networkType, securityMode, KeyName.Main, undefined, undefined, undefined);
-        expect(account.address).not.undefined;
-        expect(account.privateKey).not.undefined;
-        expect(account.privateKey).not.undefined;
-    });
-
-    it('should generateAccount brand new on remote', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT;
-        const account = configLoader.generateAccount(networkType, securityMode, KeyName.Remote, undefined, undefined, undefined);
-        expect(account.address).not.undefined;
-        expect(account.privateKey).not.undefined;
-        expect(account.privateKey).not.undefined;
-    });
-
-    it('should generateAccount brand new on voting', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN;
-        const account = configLoader.generateAccount(networkType, securityMode, KeyName.Voting, undefined, undefined, undefined);
-        expect(account.address).not.undefined;
-        expect(account.privateKey).not.undefined;
-        expect(account.privateKey).not.undefined;
-    });
-
-    it('should generateAccount raise error new', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN;
-        expect(() => configLoader.generateAccount(networkType, securityMode, KeyName.Main, undefined, undefined, undefined)).throw;
-    });
-
-    it('should generateAccount raise error new', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.PROMPT_MAIN_TRANSPORT;
-        expect(() => configLoader.generateAccount(networkType, securityMode, KeyName.Transport, undefined, undefined, undefined)).throw;
-    });
-
-    it('should generateAccount raise error new', () => {
-        const configLoader = new ConfigLoader(logger);
-        const networkType = NetworkType.TEST_NET;
-        const securityMode = PrivateKeySecurityMode.PROMPT_ALL;
-        expect(() => configLoader.generateAccount(networkType, securityMode, KeyName.Remote, undefined, undefined, undefined)).throw;
     });
 });

--- a/test/service/MigrationService.test.ts
+++ b/test/service/MigrationService.test.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { Addresses, BootstrapUtils, LoggerFactory, LogType } from '../../src';
+import { MigrationService } from '../../src/service/MigrationService';
+const logger = LoggerFactory.getLogger(LogType.Silent);
+describe('MigrationService', () => {
+    it('should migrated old addresses', async () => {
+        const service = new MigrationService(logger);
+        const oldAddresses = (await BootstrapUtils.loadYaml('./test/addresses/addresses-old.yml', false)) as Addresses;
+        const newAddresses = (await BootstrapUtils.loadYaml('./test/addresses/addresses-new.yml', false)) as Addresses;
+        const addresses = service.migrateAddresses(oldAddresses);
+        newAddresses.nodes![1].transport = addresses.nodes![1]!.transport;
+        expect(addresses).to.be.deep.eq(newAddresses);
+    });
+
+    it('should migrated not migrate new addresses', async () => {
+        const service = new MigrationService(logger);
+        const newAddresses = BootstrapUtils.loadYaml('./test/addresses/addresses-new.yml', false) as Addresses;
+        const addresses = service.migrateAddresses(newAddresses) as Addresses;
+        expect(addresses).to.be.deep.eq(newAddresses);
+    });
+});


### PR DESCRIPTION
fix: ConfigLoader split -> MigrationService, AddressesService, ConfigurationUtils
fix: addresses.sinkAddress is not generated when it's not required

Note: I had to fix some imports. If not, oclif errors when generating the docs and the cli metadata. I think it's a circular dependency somewhere. 