### PR TITLE
[hot-fix] renewCertificates on released 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.3] - Jan-20-2022
+## [1.1.3] - Jan-21-2022
 
 **Milestone**: Mainnet(1.0.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.3] - NEXT
+## [1.1.3] - Jan-20-2022
 
 **Milestone**: Mainnet(1.0.3.1)
 
@@ -12,6 +12,8 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 | ---------------- |---------| ------------------------------------------------------------------ |
 | Symbol Bootstrap | v1.1.3  | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap) |
 
+- Added `--force` to `renewCertificates`.
+- Fixed `renewCertificates` when renewing certificates created using an old Bootstrap version.
 
 ## [1.1.2] - Jan-17-2022
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ If you don't like it, let me know by creating issues on GitHub. Pull Requests ar
 * [`symbol-bootstrap link`](docs/link.md) - It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.
 * [`symbol-bootstrap modifyMultisig`](docs/modifyMultisig.md) - Create or modify a multisig account
 * [`symbol-bootstrap pack`](docs/pack.md) - It configures and packages your node into a zip file that can be uploaded to the final node machine.
-* [`symbol-bootstrap renewCertificates`](docs/renewCertificates.md) - It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
+* [`symbol-bootstrap renewCertificates`](docs/renewCertificates.md) - It renews the SSL certificates of the node regenerating the node.csr.pem files but reusing the current private keys.
 * [`symbol-bootstrap report`](docs/report.md) - it generates reStructuredText (.rst) reports describing the configuration of each node.
 * [`symbol-bootstrap resetData`](docs/resetData.md) - It removes the data keeping the generated configuration, certificates, keys and block 1.
 * [`symbol-bootstrap run`](docs/run.md) - It boots the network via docker using the generated `docker-compose.yml` file and configuration. The config and compose methods/commands need to be called before this method. This is just a wrapper for the `docker-compose up` bash call.

--- a/docs/renewCertificates.md
+++ b/docs/renewCertificates.md
@@ -1,7 +1,9 @@
 `symbol-bootstrap renewCertificates`
 ====================================
 
-It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
+It renews the SSL certificates of the node regenerating the node.csr.pem files but reusing the current private keys.
+
+The certificates are only regenerated when they are closed to expiration (30 days). If you want to renew anyway, use the --force param.
 
 This command does not change the node private key (yet). This change would require a harvesters.dat migration and relinking the node key.
 
@@ -11,7 +13,7 @@ It's recommended to backup the target folder before running this operation!
 
 ## `symbol-bootstrap renewCertificates`
 
-It renews the SSL certificates of the node regenerating the main ca.cert.pem and node.csr.pem files but reusing the current private keys.
+It renews the SSL certificates of the node regenerating the node.csr.pem files but reusing the current private keys.
 
 ```
 USAGE
@@ -30,6 +32,8 @@ OPTIONS
   -u, --user=user                  [default: current] User used to run docker images when generating the certificates.
                                    "current" means the current user.
 
+  --force                          Renew the certificates even though they are not close to expire.
+
   --logger=logger                  [default: Console,File] The loggers the command will use. Options are:
                                    Console,File,Silent. Use ',' to select multiple loggers.
 
@@ -42,6 +46,9 @@ OPTIONS
                                    (--noPassword).
 
 DESCRIPTION
+  The certificates are only regenerated when they are closed to expiration (30 days). If you want to renew anyway, use 
+  the --force param.
+
   This command does not change the node private key (yet). This change would require a harvesters.dat migration and 
   relinking the node key.
 

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -34,7 +34,7 @@ import {
 import { Logger } from '../logger';
 import { Addresses, ConfigPreset, CustomPreset, GatewayConfigPreset, NodeAccount, PeerInfo } from '../model';
 import { BootstrapUtils, KnownError, Password } from './BootstrapUtils';
-import { CertificateService } from './CertificateService';
+import { CertificateService, RenewMode } from './CertificateService';
 import { CommandUtils } from './CommandUtils';
 import { ConfigLoader } from './ConfigLoader';
 import { CryptoUtils } from './CryptoUtils';
@@ -323,7 +323,12 @@ export class ConfigService {
                     main: account.main,
                     transport: account.transport,
                 };
-                return new CertificateService(this.logger, this.params).run(presetData, account.name, providedCertificates, false);
+                return new CertificateService(this.logger, this.params).run(
+                    presetData,
+                    account.name,
+                    providedCertificates,
+                    RenewMode.ONLY_WARNING,
+                );
             }),
         );
     }


### PR DESCRIPTION
The `renewCertificates` command created on version 1.1.2 doesn't work when the certificates were created using an old version of bootstrap. 

To replicate the bug;

````shell
npm install -g symbol-bootstrap@1.1.0
symbol-bootstrap config -p mainnet -a dual --noPassword --reset

npm install -g symbol-bootstrap@1.1.2
echo 'certificateExpirationWarningInDays: 376' > custom-preset.yml  # Old way of forcing expiration
symbol-bootstrap renewCertificates --noPassword -c custom-preset.yml  # Raises an error!
````

This hotfix fixes that. Try.
````shell
npm install -g symbol-bootstrap@1.1.3-alpha-202201201146 # This branch alpha
echo 'certificateExpirationWarningInDays: 376' > custom-preset.yml  # Old way of forcing expiration
symbol-bootstrap renewCertificates --noPassword -c custom-preset.yml   # Certificate renewed!
````
Another way to renew with the new --force, 

````shell
symbol-bootstrap renewCertificates --noPassword --force 
````

Once merged, I'll release this hotfix 1.1.3.  Note that the dev branch won' be released on 1.1.3, those fixes would be for the next 1.1.4 (or maybe 1.2.0 version)

It includes:
- feat: `--force` to `renewCertificates`.
- fix: fixed `renewCertificates` when renewing certificates created from using an old Bootstrap version.
-  fix: allowing `renewCertificates` without a previous --upgrade