### PR TITLE
Fix ciruclar dependency when using CommandUtils

### DIFF
--- a/presets/mainnet/network.yml
+++ b/presets/mainnet/network.yml
@@ -27,7 +27,7 @@ minVotingKeyLifetime: 112
 maxVotingKeyLifetime: 360
 votingKeyDesiredLifetime: 360
 votingKeyDesiredFutureLifetime: 60
-lastKnownNetworkEpoch: 650
+lastKnownNetworkEpoch: 688
 stepDuration: 5m
 maxBlockFutureTime: 300ms
 maxAccountRestrictionValues: 100

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -22,7 +22,7 @@ importanceGrouping: 180
 votingSetGrouping: 720
 votingKeyDesiredLifetime: 720
 votingKeyDesiredFutureLifetime: 120
-lastKnownNetworkEpoch: 199
+lastKnownNetworkEpoch: 260
 minVotingKeyLifetime: 28
 maxVotingKeyLifetime: 720
 stepDuration: 4m

--- a/src/service/AccountResolver.ts
+++ b/src/service/AccountResolver.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import { Account, NetworkType } from 'symbol-sdk';
-import { CertificatePair, KeyName } from '../';
+import { CertificatePair } from '../model';
+import { KeyName } from '../service';
 
 /**
  * Delegate that knows how to retrieve or generate accounts.

--- a/src/service/AnnounceService.ts
+++ b/src/service/AnnounceService.ts
@@ -21,7 +21,6 @@ import {
     AccountInfo,
     Address,
     AggregateTransaction,
-    Convert,
     Currency,
     Deadline,
     IListener,
@@ -432,7 +431,7 @@ export class AnnounceService {
                     name: 'privateKey',
                     message: `Enter the 64 HEX private key of one of the addresses ${expectedDescription}. Already entered ${providedAccounts.length} out of ${minApproval} required cosigners.`,
                     type: 'password',
-                    validate: AnnounceService.isValidPrivateKey,
+                    validate: CommandUtils.isValidPrivateKey,
                 },
             ]);
             const privateKey = responses.privateKey;
@@ -474,10 +473,6 @@ export class AnnounceService {
                 }
             }
         }
-    }
-
-    public static isValidPrivateKey(input: string): boolean | string {
-        return Convert.isHexString(input, 64) ? true : 'Invalid private key. It must be has 64 hex characters!';
     }
 
     private async getAccountInfo(repositoryFactory: RepositoryFactory, mainAccountAddress: Address): Promise<AccountInfo | undefined> {

--- a/src/service/BootstrapAccountResolver.ts
+++ b/src/service/BootstrapAccountResolver.ts
@@ -15,7 +15,9 @@
  */
 import { prompt } from 'inquirer';
 import { Account, NetworkType, PublicAccount } from 'symbol-sdk';
-import { AccountResolver, CertificatePair, CommandUtils, KeyName, KnownError, Logger } from '../';
+import { Logger } from '../logger';
+import { CertificatePair } from '../model';
+import { AccountResolver, CommandUtils, KeyName, KnownError } from './';
 
 /**
  * Prompt ready implementation of the account resolver.

--- a/test/service/BootstrapAccountResolver.test.ts
+++ b/test/service/BootstrapAccountResolver.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Fernando Boucquez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { it } from 'mocha';
+import { Account, NetworkType } from 'symbol-sdk';
+import { BootstrapAccountResolver, KeyName, LoggerFactory, LogType } from '../../src';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { StdUtils } from '../utils/StdUtils';
+
+describe('BootstrapAccountResolver', () => {
+    const logger = LoggerFactory.getLogger(LogType.Silent);
+    const networkType = NetworkType.TEST_NET;
+    const resolver = new BootstrapAccountResolver(logger);
+    const testAccount = Account.generateNewAccount(networkType);
+
+    it('should resolveAccount when private key is provided', async () => {
+        const account = await resolver.resolveAccount(
+            networkType,
+            {
+                privateKey: testAccount.privateKey,
+                publicKey: testAccount.publicKey,
+            },
+            KeyName.Main,
+            'some node',
+            'some description',
+            undefined,
+        );
+        expect(account).to.be.deep.eq(testAccount);
+    });
+
+    it('should resolveAccount prompt private key when private key is provided', async () => {
+        StdUtils.in(['INVALID', '\n', testAccount.privateKey, '\n']);
+        const account = await resolver.resolveAccount(
+            networkType,
+            {
+                publicKey: testAccount.publicKey,
+            },
+            KeyName.Main,
+            'some node',
+            'some description',
+            undefined,
+        );
+        expect(account).to.be.deep.eq(testAccount);
+    });
+
+    it('should resolveAccount generate account when no account is not provided', async () => {
+        const account = await resolver.resolveAccount(networkType, undefined, KeyName.Main, 'some node', 'some description', undefined);
+        expect(account).to.not.be.undefined;
+        expect(account).to.be.not.deep.eq(testAccount);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/fboucquez/symbol-bootstrap/issues/378

Fixes the circular dependency by fine-tuning the imports. Yes, it's ugly, but the but it's also ugly. 

Also:
- added BootstrapAccountResolver.ts unit tests
- removed duplicated isValidPrivateKey from AnnounceService
- updated network epochs for offline