### PR TITLE
fix: openssl security vulnerability fixed with symbol-server:gcc-10-10.0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.6] - Mar-15-2022
+
+**Milestone**: Mainnet(1.0.3.3)
+
+| Package          | Version | Link                                                               |
+| ---------------- |---------| ------------------------------------------------------------------ |
+| Symbol Bootstrap | v1.1.6  | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap) |
+
+- Fixed openssl security vulnerability [issue](https://www.opencve.io/cve/CVE-2022-0778)
+
 ## [1.1.5] - Mar-1-2022
 
 **Milestone**: Mainnet(1.0.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.6] - Mar-15-2022
+## [1.1.6] - Mar-16-2022
 
 **Milestone**: Mainnet(1.0.3.3)
 

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -64,7 +64,7 @@ maxNameSize: 64
 maxChildNamespaces: 256
 maxNamespaceDepth: 3
 batchVerificationRandomSource:
-symbolServerImage: symbolplatform/symbol-server:gcc-10-1.0.3.1
+symbolServerImage: symbolplatform/symbol-server:gcc-10-1.0.3.3
 symbolRestImage: symbolplatform/symbol-rest:2.4.0
 symbolExplorerImage: symbolplatform/symbol-explorer:1.1.1-alpha-202110290945
 symbolFaucetImage: symbolplatform/symbol-faucet:1.0.1-alpha-202110131930

--- a/test/composes/expected-docker-compose-bootstrap-custom-compose.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom-compose.yml
@@ -23,7 +23,7 @@ services:
     peer-node-0:
         user: '1000:1000'
         container_name: peer-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-0 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -47,7 +47,7 @@ services:
     peer-node-1:
         user: '1000:1000'
         container_name: peer-node-1
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-1 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -71,7 +71,7 @@ services:
     api-node-0:
         user: '1000:1000'
         container_name: api-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-0 NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -90,7 +90,7 @@ services:
     api-node-broker-0:
         user: '1000:1000'
         container_name: api-node-broker-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-0 NORMAL
         ports:

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -16,7 +16,7 @@ services:
             - '../databases/db-0:/dbdata:rw'
     peer-node-0:
         container_name: peer-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-0 DEBUG false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -38,7 +38,7 @@ services:
         hostname: peer-node-0
     peer-node-1:
         container_name: peer-node-1
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-1 DEBUG false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -60,7 +60,7 @@ services:
         hostname: peer-node-1
     api-node-0:
         container_name: api-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-0 DEBUG true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -83,7 +83,7 @@ services:
         hostname: api-node-0
     api-node-broker-0:
         container_name: api-node-broker-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-0 DEBUG
         ports:

--- a/test/composes/expected-docker-compose-bootstrap-demo.yml
+++ b/test/composes/expected-docker-compose-bootstrap-demo.yml
@@ -19,7 +19,7 @@ services:
         privileged: true
     node:
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node DEBUG true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -39,7 +39,7 @@ services:
         privileged: true
     broker:
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker DEBUG
         stop_signal: SIGINT

--- a/test/composes/expected-docker-compose-bootstrap-dual.yml
+++ b/test/composes/expected-docker-compose-bootstrap-dual.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -31,7 +31,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-docker-compose-bootstrap-repeat.yml
+++ b/test/composes/expected-docker-compose-bootstrap-repeat.yml
@@ -59,7 +59,7 @@ services:
     peer-node-0:
         user: '1000:1000'
         container_name: peer-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-0 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -77,7 +77,7 @@ services:
     peer-node-1:
         user: '1000:1000'
         container_name: peer-node-1
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-1 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -95,7 +95,7 @@ services:
     peer-node-2:
         user: '1000:1000'
         container_name: peer-node-2
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-2 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -113,7 +113,7 @@ services:
     api-node-0:
         user: '1000:1000'
         container_name: api-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-0 NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -132,7 +132,7 @@ services:
     api-node-1:
         user: '1000:1000'
         container_name: api-node-1
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-1 NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -151,7 +151,7 @@ services:
     api-node-2:
         user: '1000:1000'
         container_name: api-node-2
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-2 NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -170,7 +170,7 @@ services:
     api-node-3:
         user: '1000:1000'
         container_name: api-node-3
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-3 NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -189,7 +189,7 @@ services:
     api-node-broker-0:
         user: '1000:1000'
         container_name: api-node-broker-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-0 NORMAL
         ports:
@@ -204,7 +204,7 @@ services:
     api-node-broker-1:
         user: '1000:1000'
         container_name: api-node-broker-1
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-1 NORMAL
         ports:
@@ -219,7 +219,7 @@ services:
     api-node-broker-2:
         user: '1000:1000'
         container_name: api-node-broker-2
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-2 NORMAL
         ports:
@@ -234,7 +234,7 @@ services:
     api-node-broker-3:
         user: '1000:1000'
         container_name: api-node-broker-3
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-3 NORMAL
         ports:

--- a/test/composes/expected-docker-compose-bootstrap.yml
+++ b/test/composes/expected-docker-compose-bootstrap.yml
@@ -17,7 +17,7 @@ services:
     peer-node-0:
         user: '1000:1000'
         container_name: peer-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-0 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -35,7 +35,7 @@ services:
     peer-node-1:
         user: '1000:1000'
         container_name: peer-node-1
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker peer-node-1 NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -53,7 +53,7 @@ services:
     api-node-0:
         user: '1000:1000'
         container_name: api-node-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker api-node-0 NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -72,7 +72,7 @@ services:
     api-node-broker-0:
         user: '1000:1000'
         container_name: api-node-broker-0
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server api-node-broker-0 NORMAL
         ports:

--- a/test/composes/expected-mainnet-api-compose.yml
+++ b/test/composes/expected-mainnet-api-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -31,7 +31,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-mainnet-custom-services.yml
+++ b/test/composes/expected-mainnet-custom-services.yml
@@ -23,7 +23,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -52,7 +52,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-mainnet-dual-compose.yml
+++ b/test/composes/expected-mainnet-dual-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -31,7 +31,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-mainnet-peer-compose.yml
+++ b/test/composes/expected-mainnet-peer-compose.yml
@@ -3,7 +3,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-testnet-api-compose.yml
+++ b/test/composes/expected-testnet-api-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -31,7 +31,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-testnet-dual-compose.yml
+++ b/test/composes/expected-testnet-dual-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -31,7 +31,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-testnet-httpsproxy-compose.yml
+++ b/test/composes/expected-testnet-httpsproxy-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -36,7 +36,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-testnet-native-ssl-compose.yml
+++ b/test/composes/expected-testnet-native-ssl-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -36,7 +36,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT

--- a/test/composes/expected-testnet-peer-compose.yml
+++ b/test/composes/expected-testnet-peer-compose.yml
@@ -3,7 +3,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL false
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-testnet-voting-compose.yml
+++ b/test/composes/expected-testnet-voting-compose.yml
@@ -15,7 +15,7 @@ services:
     node:
         user: '1000:1000'
         container_name: node
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data server broker node NORMAL true
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -31,7 +31,7 @@ services:
     broker:
         user: '1000:1000'
         container_name: broker
-        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.1'
+        image: 'symbolplatform/symbol-server:gcc-10-1.0.3.3'
         working_dir: /symbol-workdir
         command: /bin/bash /symbol-commands/start.sh /usr/catapult ./data broker server broker NORMAL
         stop_signal: SIGINT


### PR DESCRIPTION
Fixes the openssl security vulnerability [issue](https://www.opencve.io/cve/CVE-2022-0778)

@fboucquez I think it's ready to be merged now but could you pls check with @Wayonb before you merge & release? Thanks :)